### PR TITLE
fix upnp nat traversal

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -248,6 +248,8 @@ export class OceanP2P extends EventEmitter {
       // })
       node.services.pubsub.subscribe(this._topic)
       node.services.pubsub.publish(this._topic, encoding('online'))
+      ;(node.services.upnpNAT as any).mapIpAddresses()
+
       return node
     } catch (e) {
       P2P_CONSOLE_LOGGER.logMessageWithEmoji(

--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -248,7 +248,11 @@ export class OceanP2P extends EventEmitter {
       // })
       node.services.pubsub.subscribe(this._topic)
       node.services.pubsub.publish(this._topic, encoding('online'))
-      ;(node.services.upnpNAT as any).mapIpAddresses()
+      // ;(node.services.upnpNAT as any).mapIpAddresses()
+      ;(node.services.upnpNAT as any).mapIpAddresses().catch((err: any) => {
+        // hole punching errors are non-fatal
+        console.error(err)
+      })
 
       return node
     } catch (e) {

--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -194,8 +194,8 @@ export class OceanP2P extends EventEmitter {
             maxOutboundStreams: config.p2pConfig.dhtMaxOutboundStreams,
 
             clientMode: false, // this should be true for edge devices
-            kBucketSize: 20,
-            protocolPrefix: '/ocean/nodes/1.0.0'
+            kBucketSize: 20
+            // protocolPrefix: '/ocean/nodes/1.0.0'
             // randomWalk: {
             //  enabled: true,            // Allows to disable discovery (enabled by default)
             //  interval: 300e3,


### PR DESCRIPTION
While debuging upnp nat traversal, I realized that mappingIP code is triggered too soon, before transportManager has all bind interfaces.

Just triggering it manually after node, and works like a charm:
![Screenshot 2023-12-19 112220](https://github.com/oceanprotocol/ocean-node/assets/7489447/a79ee4d2-8426-4500-8643-f1a92b4da47f)

