### PR TITLE
unit test to double check if all supported commands have handlers

### DIFF
--- a/src/test/unit/commands.test.ts
+++ b/src/test/unit/commands.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import {
+  ENVIRONMENT_VARIABLES,
+  SUPPORTED_PROTOCOL_COMMANDS,
+  getConfig
+} from '../../utils/index.js'
+import {
+  buildEnvOverrideConfig,
+  setupEnvironment,
+  tearDownEnvironment
+} from '../utils/utils.js'
+import { OceanNodeConfig } from '../../@types/OceanNode.js'
+import { OceanP2P } from '../../components/P2P/index.js'
+import { CoreHandlersRegistry } from '../../components/core/coreHandlersRegistry.js'
+import { Handler } from '../../components/core/handler.js'
+
+describe('Commands and handlers', async () => {
+  const envOverrides = buildEnvOverrideConfig(
+    [ENVIRONMENT_VARIABLES.PRIVATE_KEY],
+    ['0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58']
+  )
+  before(() => {
+    setupEnvironment(null, envOverrides)
+  })
+
+  it('Check that all supported commands have registered handlers', async () => {
+    // To make sure we do not forget to register handlers
+    const config: OceanNodeConfig = await getConfig()
+    const nodeP2P = new OceanP2P(config)
+    for (const command of SUPPORTED_PROTOCOL_COMMANDS) {
+      expect(
+        CoreHandlersRegistry.getInstance(nodeP2P).getHandler(command)
+      ).to.be.instanceof(Handler)
+    }
+  })
+
+  after(() => {
+    tearDownEnvironment(envOverrides)
+  })
+})

--- a/src/test/unit/commands.test.ts
+++ b/src/test/unit/commands.test.ts
@@ -1,28 +1,11 @@
 import { expect } from 'chai'
-import {
-  ENVIRONMENT_VARIABLES,
-  SUPPORTED_PROTOCOL_COMMANDS,
-  getConfig
-} from '../../utils/index.js'
-import {
-  buildEnvOverrideConfig,
-  setupEnvironment,
-  tearDownEnvironment
-} from '../utils/utils.js'
+import { SUPPORTED_PROTOCOL_COMMANDS, getConfig } from '../../utils/index.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { OceanP2P } from '../../components/P2P/index.js'
 import { CoreHandlersRegistry } from '../../components/core/coreHandlersRegistry.js'
 import { Handler } from '../../components/core/handler.js'
 
 describe('Commands and handlers', async () => {
-  const envOverrides = buildEnvOverrideConfig(
-    [ENVIRONMENT_VARIABLES.PRIVATE_KEY],
-    ['0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58']
-  )
-  before(() => {
-    setupEnvironment(null, envOverrides)
-  })
-
   it('Check that all supported commands have registered handlers', async () => {
     // To make sure we do not forget to register handlers
     const config: OceanNodeConfig = await getConfig()
@@ -32,9 +15,5 @@ describe('Commands and handlers', async () => {
         CoreHandlersRegistry.getInstance(nodeP2P).getHandler(command)
       ).to.be.instanceof(Handler)
     }
-  })
-
-  after(() => {
-    tearDownEnvironment(envOverrides)
   })
 })


### PR DESCRIPTION
Fixes #222 .

Changes proposed in this PR:

- 1 Unit Test to double check that all supported commands have 1 registered handler (to make sure we don't forget any) 
- If this test fails we know that either we do not registered the new handler or we did not updated `SUPPORTED_PROTOCOL_COMMANDS` correctly