### PR TITLE
add C2C cluster env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ export IPFS_GATEWAY='https://ipfs.io/'
 export ARWEAVE_GATEWAY='https://arweave.net/'
 ```
 
+For configuring a C2D (Compute to Data) cluster(s), please set the following environment variable (array of 1 or multiple cluster URLS):
+
+```bash
+export OPERATOR_SERVICE_URL=[\"http://example.c2d.cluster1.com\",\"http://example.cd2.cluster2.com\"]
+```
+
 Then start the node:
 
 ```bash

--- a/src/@types/OceanNode.ts
+++ b/src/@types/OceanNode.ts
@@ -14,6 +14,11 @@ export interface OceanNodeKeys {
   ethAddress: string
 }
 
+export interface C2DClusterInfo {
+  url: string
+  hash: string
+}
+
 export interface OceanNodeP2PConfig {
   bootstrapNodes: string[]
   ipV4BindAddress: string | null
@@ -42,6 +47,7 @@ export interface OceanNodeConfig {
   httpPort: number
   feeStrategy: FeeStrategy
   supportedNetworks?: RPCS
+  c2dClusters: C2DClusterInfo[]
 }
 
 export interface P2PStatusResponse {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,7 +13,7 @@ import {
   OCEAN_ARTIFACTS_ADDRESSES_PER_CHAIN
 } from '../utils/address.js'
 import { CONFIG_CONSOLE_LOGGER } from './logging/common.js'
-import { create256Hash } from './crypt'
+import { create256Hash } from './crypt.js'
 
 export async function getPeerIdFromPrivateKey(
   privateKey: string

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -246,5 +246,10 @@ export const ENVIRONMENT_VARIABLES: Record<any, EnvVariable> = {
     name: 'AUTHORIZED_DECRYPTERS',
     value: process.env.AUTHORIZED_DECRYPTERS,
     required: false
+  },
+  OPERATOR_SERVICE_URL: {
+    name: 'OPERATOR_SERVICE_URL',
+    value: process.env.OPERATOR_SERVICE_URL,
+    required: false // without provider we don't have it
   }
 }

--- a/src/utils/crypt.ts
+++ b/src/utils/crypt.ts
@@ -50,3 +50,8 @@ export async function decrypt(data: Uint8Array, algorithm: string): Promise<Buff
   }
   return decryptedData
 }
+// this can be handy as we do this kind of hash in multiple places
+export function create256Hash(input: string): string {
+  const result = crypto.createHash('sha256').update(input).digest('hex')
+  return '0x' + result
+}


### PR DESCRIPTION
Fixes #226 

Changes proposed in this PR:

-  Add new config `OPERATOR_SERVICE_URL` (array of 1 or multiple cluster URLS)
-  Updated README

(when we start actually using this and with a c2d env ready, we will have to update the CI env as well, for instance)