### PR TITLE
fix unit test on commands.ts - pick mismatches in both directions

### DIFF
--- a/src/components/core/coreHandlersRegistry.ts
+++ b/src/components/core/coreHandlersRegistry.ts
@@ -53,7 +53,7 @@ export class CoreHandlersRegistry {
   // eslint-disable-next-line no-use-before-define
   private static instance: CoreHandlersRegistry
   // map of handlers registered
-  private readonly coreHandlers: Map<string, Handler> = new Map<string, Handler>()
+  private coreHandlers: Map<string, Handler> = new Map<string, Handler>()
 
   // private readonly node: OceanP2P
   private constructor(node: OceanNode) {
@@ -134,7 +134,7 @@ export class CoreHandlersRegistry {
     return this.coreHandlers.has(handlerName)
   }
 
-  public getExistingHandlers(): Handler[] {
-    return Array.from(this.coreHandlers.values())
+  public getRegisteredCommands(): string[] {
+    return Array.from(this.coreHandlers.keys())
   }
 }

--- a/src/components/core/coreHandlersRegistry.ts
+++ b/src/components/core/coreHandlersRegistry.ts
@@ -53,7 +53,7 @@ export class CoreHandlersRegistry {
   // eslint-disable-next-line no-use-before-define
   private static instance: CoreHandlersRegistry
   // map of handlers registered
-  private coreHandlers: Map<string, Handler> = new Map<string, Handler>()
+  private readonly coreHandlers: Map<string, Handler> = new Map<string, Handler>()
 
   // private readonly node: OceanP2P
   private constructor(node: OceanNode) {
@@ -132,5 +132,9 @@ export class CoreHandlersRegistry {
 
   public hasHandlerFor(handlerName: string): boolean {
     return this.coreHandlers.has(handlerName)
+  }
+
+  public getExistingHandlers(): Handler[] {
+    return Array.from(this.coreHandlers.values())
   }
 }

--- a/src/test/unit/commands.test.ts
+++ b/src/test/unit/commands.test.ts
@@ -14,4 +14,11 @@ describe('Commands and handlers', async () => {
       )
     }
   })
+
+  it('Check that supported commands and handlers match', async () => {
+    // To make sure we do not forget to register anything on supported commands
+    const node: OceanNode = OceanNode.getInstance()
+    const handlers: Handler[] = node.getCoreHandlers().getExistingHandlers()
+    expect(SUPPORTED_PROTOCOL_COMMANDS.length).to.be.equal(handlers.length)
+  })
 })

--- a/src/test/unit/commands.test.ts
+++ b/src/test/unit/commands.test.ts
@@ -18,7 +18,7 @@ describe('Commands and handlers', async () => {
   it('Check that supported commands and handlers match', async () => {
     // To make sure we do not forget to register anything on supported commands
     const node: OceanNode = OceanNode.getInstance()
-    const handlers: Handler[] = node.getCoreHandlers().getExistingHandlers()
+    const handlers: string[] = node.getCoreHandlers().getRegisteredCommands()
     expect(SUPPORTED_PROTOCOL_COMMANDS.length).to.be.equal(handlers.length)
   })
 })


### PR DESCRIPTION
Fixes #245 

Changes proposed in this PR:

- Make sure unit test pick both unregistered/missing handlers or new commands (with handler) but not added to SUPPORTED_PROTOCOL_COMMANDS
