### PR TITLE
fix error on publish + no signer/no account  /  metadata events error

### DIFF
--- a/src/@types/blockchain.ts
+++ b/src/@types/blockchain.ts
@@ -1,8 +1,8 @@
 export interface SupportedNetwork {
   chainId: number
-  network: string
   rpc: string
-  chunkSize: number
+  network?: string
+  chunkSize?: number
 }
 
 export interface RPCS {

--- a/src/@types/commands.ts
+++ b/src/@types/commands.ts
@@ -39,9 +39,10 @@ export interface DDOCommand extends Command {
 }
 export interface GetDdoCommand extends DDOCommand {}
 export interface FindDDOCommand extends DDOCommand {}
-export interface ValidateDDOCommand extends DDOCommand {
-  chainId: number
-  nftAddress: string
+// this one gets the raw ddo
+// https://github.com/oceanprotocol/ocean-node/issues/47
+export interface ValidateDDOCommand extends Command {
+  ddo: DDO
 }
 
 export interface GetEnvironmentsCommand extends Command {

--- a/src/components/Indexer/crawlerThread.ts
+++ b/src/components/Indexer/crawlerThread.ts
@@ -49,10 +49,17 @@ async function updateLastIndexedBlockNumber(block: number): Promise<void> {
   }
 }
 export async function proccesNetworkData(): Promise<void> {
+  const deployedBlock = await getDeployedContractBlock(rpcDetails.chainId)
+  if (deployedBlock == null && lastIndexedBlock == null) {
+    INDEXER_LOGGER.logMessage(
+      `chain: ${rpcDetails.chainId} Both deployed block and last indexed block are null. Cannot proceed further on this chain`,
+      true
+    )
+    return
+  }
+
   while (true) {
     const networkHeight = await getNetworkHeight(provider)
-
-    const deployedBlock = await getDeployedContractBlock(rpcDetails.chainId)
 
     const startBlock =
       lastIndexedBlock && lastIndexedBlock > deployedBlock

--- a/src/components/Indexer/processor.ts
+++ b/src/components/Indexer/processor.ts
@@ -89,7 +89,7 @@ class BaseEventProcessor {
     let ddo
     if (flag === '0x02') {
       INDEXER_LOGGER.logMessage(
-        `Decrypting DDO  from network: ${this.networkId} created by: ${eventCreator} ecnrypted by: ${decryptorURL}`
+        `Decrypting DDO  from network: ${this.networkId} created by: ${eventCreator} encrypted by: ${decryptorURL}`
       )
       const nonce = Date.now().toString()
       const { keys } = await getConfiguration()

--- a/src/components/Indexer/processor.ts
+++ b/src/components/Indexer/processor.ts
@@ -285,7 +285,6 @@ export class MetadataEventProcessor extends BaseEventProcessor {
         decodedEventData.args[5],
         decodedEventData.args[4]
       )
-      INDEXER_LOGGER.logMessage(`Got ${ddo}`, true)
       ddo.datatokens = this.getTokenInfo(ddo.services)
       INDEXER_LOGGER.logMessage(
         `Processed new DDO data ${ddo.id} with txHash ${event.transactionHash} from block ${event.blockNumber}`,

--- a/src/components/Indexer/utils.ts
+++ b/src/components/Indexer/utils.ts
@@ -1,4 +1,4 @@
-import { JsonRpcApiProvider, ethers, getAddress } from 'ethers'
+import { JsonRpcApiProvider, Signer, ethers, getAddress } from 'ethers'
 import localAdressFile from '@oceanprotocol/contracts/addresses/address.json' assert { type: 'json' }
 import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json' assert { type: 'json' }
 import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json' assert { type: 'json' }
@@ -96,6 +96,7 @@ export const getNetworkHeight = async (provider: JsonRpcApiProvider) => {
 }
 
 export const processBlocks = async (
+  signer: Signer,
   provider: JsonRpcApiProvider,
   network: number,
   lastIndexedBlock: number,
@@ -109,7 +110,7 @@ export const processBlocks = async (
       toBlock: lastIndexedBlock + count,
       topics: [eventHashes]
     })
-    const events = await processChunkLogs(blockLogs, provider, network)
+    const events = await processChunkLogs(blockLogs, signer, provider, network)
 
     return {
       lastBlock: lastIndexedBlock + count,
@@ -131,6 +132,7 @@ function findEventByKey(keyToFind: string): NetworkEvent {
 
 export const processChunkLogs = async (
   logs: readonly ethers.Log[],
+  signer: Signer,
   provider: JsonRpcApiProvider,
   chainId: number
 ): Promise<BlocksEvents> => {
@@ -138,39 +140,38 @@ export const processChunkLogs = async (
   if (logs.length > 0) {
     for (const log of logs) {
       const event = findEventByKey(log.topics[0])
-      if (
-        event &&
-        (event.type === EVENTS.METADATA_CREATED || event.type === EVENTS.METADATA_UPDATED)
-      ) {
-        INDEXER_LOGGER.logMessage(`-- ${event.type} triggered`, true)
-        const processor = await getMetadataEventProcessor(chainId)
-        storeEvents[event.type] = await processor.processEvent(
-          log,
-          chainId,
-          provider,
-          event.type
-        )
-      } else if (event && event.type === EVENTS.METADATA_STATE) {
-        INDEXER_LOGGER.logMessage(`-- ${event.type} triggered`, true)
-        const processor = await getMetadataStateEventProcessor(chainId)
-        storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
-      } else if (event && event.type === EVENTS.EXCHANGE_CREATED) {
-        INDEXER_LOGGER.logMessage('-- EXCHANGE_CREATED -- ', true)
-        storeEvents[event.type] = await procesExchangeCreated()
-      } else if (event && event.type === EVENTS.EXCHANGE_RATE_CHANGED) {
-        INDEXER_LOGGER.logMessage('-- EXCHANGE_RATE_CHANGED -- ', true)
-        storeEvents[event.type] = await processExchangeRateChanged()
-      } else if (event && event.type === EVENTS.ORDER_STARTED) {
-        INDEXER_LOGGER.logMessage(`-- ${event.type} triggered`, true)
-        const processor = await getOrderStartedEventProcessor(chainId)
-        storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
-      } else if (event && event.type === EVENTS.ORDER_REUSED) {
-        INDEXER_LOGGER.logMessage(`-- ${event.type} triggered`, true)
-        const processor = await getOrderReusedEventProcessor(chainId)
-        storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
-      } else if (event && event.type === EVENTS.TOKEN_URI_UPDATE) {
-        INDEXER_LOGGER.logMessage('-- TOKEN_URI_UPDATE -- ', true)
-        storeEvents[event.type] = await processTokenUriUpadate()
+
+      if (event && Object.values(EVENTS).includes(event.type)) {
+        // only log & process the ones we support
+        INDEXER_LOGGER.logMessage(`-- ${event.type} -- triggered`, true)
+        if (
+          event.type === EVENTS.METADATA_CREATED ||
+          event.type === EVENTS.METADATA_UPDATED
+        ) {
+          const processor = await getMetadataEventProcessor(chainId)
+          storeEvents[event.type] = await processor.processEvent(
+            log,
+            chainId,
+            signer,
+            provider,
+            event.type
+          )
+        } else if (event.type === EVENTS.METADATA_STATE) {
+          const processor = await getMetadataStateEventProcessor(chainId)
+          storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
+        } else if (event.type === EVENTS.EXCHANGE_CREATED) {
+          storeEvents[event.type] = await procesExchangeCreated()
+        } else if (event.type === EVENTS.EXCHANGE_RATE_CHANGED) {
+          storeEvents[event.type] = await processExchangeRateChanged()
+        } else if (event.type === EVENTS.ORDER_STARTED) {
+          const processor = await getOrderStartedEventProcessor(chainId)
+          storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
+        } else if (event.type === EVENTS.ORDER_REUSED) {
+          const processor = await getOrderReusedEventProcessor(chainId)
+          storeEvents[event.type] = await processor.processEvent(log, chainId, provider)
+        } else if (event.type === EVENTS.TOKEN_URI_UPDATE) {
+          storeEvents[event.type] = await processTokenUriUpadate()
+        }
       }
     }
     return storeEvents
@@ -192,28 +193,28 @@ const processTokenUriUpadate = async (): Promise<string> => {
 }
 
 export const getNFTContract = async (
-  provider: JsonRpcApiProvider,
+  signer: Signer,
   address: string
 ): Promise<ethers.Contract> => {
   address = getAddress(address)
-  return getContract(provider, 'ERC721Template', address)
+  return getContract(signer, 'ERC721Template', address)
 }
 
 export const getNFTFactory = async (
-  provider: JsonRpcApiProvider,
+  signer: Signer,
   address: string
 ): Promise<ethers.Contract> => {
   address = getAddress(address)
-  return await getContract(provider, 'ERC721Factory', address)
+  return await getContract(signer, 'ERC721Factory', address)
 }
 
 async function getContract(
-  provider: JsonRpcApiProvider,
+  signer: Signer,
   contractName: string,
   address: string
 ): Promise<ethers.Contract> {
   const abi = getContractDefinition(contractName)
-  return new ethers.Contract(getAddress(address), abi, await provider.getSigner())
+  return new ethers.Contract(getAddress(address), abi, signer) // was provider.getSigner() => thow no account
 }
 
 function getContractDefinition(contractName: string): any {

--- a/src/components/Indexer/utils.ts
+++ b/src/components/Indexer/utils.ts
@@ -143,19 +143,23 @@ export const processChunkLogs = async (
 
       if (event && Object.values(EVENTS).includes(event.type)) {
         // only log & process the ones we support
-        INDEXER_LOGGER.logMessage(`-- ${event.type} -- triggered`, true)
+        INDEXER_LOGGER.logMessage(
+          `-- ${event.type} -- triggered for ${log.transactionHash}`,
+          true
+        )
         if (
           event.type === EVENTS.METADATA_CREATED ||
           event.type === EVENTS.METADATA_UPDATED
         ) {
           const processor = await getMetadataEventProcessor(chainId)
-          storeEvents[event.type] = await processor.processEvent(
+          const rets = await processor.processEvent(
             log,
             chainId,
             signer,
             provider,
             event.type
           )
+          if (rets) storeEvents[event.type] = rets
         } else if (event.type === EVENTS.METADATA_STATE) {
           const processor = await getMetadataStateEventProcessor(chainId)
           storeEvents[event.type] = await processor.processEvent(log, chainId, provider)

--- a/src/components/core/ddoHandler.ts
+++ b/src/components/core/ddoHandler.ts
@@ -1,5 +1,5 @@
 import { Handler } from './handler.js'
-import { MetadataStates, PROTOCOL_COMMANDS } from '../../utils/constants.js'
+import { EVENTS, MetadataStates, PROTOCOL_COMMANDS } from '../../utils/constants.js'
 import { P2PCommandResponse } from '../../@types'
 import { Readable } from 'stream'
 import {
@@ -158,7 +158,7 @@ export class DecryptDdoHandler extends Handler {
             data: receipt.logs[0].data
           }
           const eventData = abiInterface.parseLog(eventObject)
-          if (eventData.name !== 'MetadataCreated') {
+          if (eventData.name !== EVENTS.METADATA_CREATED) {
             throw new Error(`event name ${eventData.name}`)
           }
           flags = parseInt(eventData.args[3], 16)

--- a/src/components/core/ddoHandler.ts
+++ b/src/components/core/ddoHandler.ts
@@ -648,20 +648,24 @@ export class FindDdoHandler extends Handler {
 export class ValidateDDOHandler extends Handler {
   async handle(task: ValidateDDOCommand): Promise<P2PCommandResponse> {
     try {
-      const ddo = await this.getOceanNode().getDatabase().ddo.retrieve(task.id)
-      if (!ddo) {
-        CORE_LOGGER.logMessageWithEmoji(
-          `DDO ${task.id} was not found the database.`,
-          true,
-          GENERIC_EMOJIS.EMOJI_CROSS_MARK,
-          LOG_LEVELS_STR.LEVEL_ERROR
-        )
-        return {
-          stream: null,
-          status: { httpStatus: 404, error: 'Not found' }
-        }
-      }
-      const validation = await validateObject(ddo, task.chainId, task.nftAddress)
+      // const ddo = await this.getOceanNode().getDatabase().ddo.retrieve(task.ddo.id)
+      // if (!ddo) {
+      //   CORE_LOGGER.logMessageWithEmoji(
+      //     `DDO ${task.id} was not found the database.`,
+      //     true,
+      //     GENERIC_EMOJIS.EMOJI_CROSS_MARK,
+      //     LOG_LEVELS_STR.LEVEL_ERROR
+      //   )
+      //   return {
+      //     stream: null,
+      //     status: { httpStatus: 404, error: 'Not found' }
+      //   }
+      // }
+      const validation = await validateObject(
+        task.ddo,
+        task.ddo.chainId,
+        task.ddo.nftAddress
+      )
       if (validation[0] === false) {
         CORE_LOGGER.logMessageWithEmoji(
           `Validation failed with error: ${validation[1]}`,

--- a/src/components/core/ddoHandler.ts
+++ b/src/components/core/ddoHandler.ts
@@ -22,7 +22,7 @@ import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templat
 import { decrypt } from '../../utils/crypt.js'
 import { createHash } from 'crypto'
 import lzma from 'lzma-native'
-import { validateObject } from './utils/validateDdoHandler.js'
+import { getValidationSignature, validateObject } from './utils/validateDdoHandler.js'
 import { getConfiguration } from '../../utils/config.js'
 import {
   GetDdoCommand,
@@ -678,8 +678,11 @@ export class ValidateDDOHandler extends Handler {
           status: { httpStatus: 400, error: `Validation error: ${validation[1]}` }
         }
       }
+
+      // TODO check this fn
+      const hash = await getValidationSignature(JSON.stringify(task.ddo))
       return {
-        stream: Readable.from(JSON.stringify({})),
+        stream: Readable.from(JSON.stringify(hash)),
         status: { httpStatus: 200 }
       }
     } catch (error) {

--- a/src/components/core/encryptHandler.ts
+++ b/src/components/core/encryptHandler.ts
@@ -21,7 +21,7 @@ export class EncryptHandler extends Handler {
       // do encrypt magic
       const encryptedData = await encrypt(blobData, task.encryptionType)
       return {
-        stream: Readable.from(encryptedData.toString('hex')),
+        stream: Readable.from('0x' + encryptedData.toString('hex')),
         status: { httpStatus: 200 }
       }
     } catch (error) {

--- a/src/components/core/utils/validateDdoHandler.ts
+++ b/src/components/core/utils/validateDdoHandler.ts
@@ -76,7 +76,7 @@ export async function validateObject(
   chainId: number,
   nftAddress: string
 ): Promise<[boolean, Record<string, string>]> {
-  const ddoCopy = obj
+  const ddoCopy = JSON.parse(JSON.stringify(obj))
   ddoCopy['@type'] = 'DDO'
   const extraErrors: Record<string, string> = {}
   if (!('@context' in obj)) {

--- a/src/components/httpRoutes/aquarius.ts
+++ b/src/components/httpRoutes/aquarius.ts
@@ -6,6 +6,7 @@ import { LOG_LEVELS_STR } from '../../utils/logging/Logger.js'
 import { GetDdoHandler, ValidateDDOHandler } from '../core/ddoHandler.js'
 import { QueryHandler } from '../core/queryHandler.js'
 import { HTTP_LOGGER } from '../../utils/logging/common.js'
+import { DDO } from '../../@types/DDO/DDO.js'
 
 export const aquariusRoutes = express.Router()
 
@@ -138,7 +139,7 @@ aquariusRoutes.post('/assets/ddo/validate', async (req, res) => {
       res.status(400).send('Missing DDO object')
       return
     }
-    const ddo = JSON.parse(req.body)
+    const ddo = JSON.parse(req.body) as DDO
 
     if (!ddo.version) {
       res.status(400).send('Missing DDO version')
@@ -147,9 +148,7 @@ aquariusRoutes.post('/assets/ddo/validate', async (req, res) => {
 
     const node = req.oceanNode
     const result = await new ValidateDDOHandler(node).handle({
-      id: ddo.id,
-      chainId: ddo.chainId,
-      nftAddress: ddo.nftAddress,
+      ddo,
       command: PROTOCOL_COMMANDS.VALIDATE_DDO
     })
     if (result.stream) {

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -20,7 +20,8 @@ providerRoutes.post('/decrypt', async (req, res) => {
     })
     if (result.stream) {
       const decryptedData = await streamToString(result.stream as Readable)
-      res.status(201).send(decryptedData)
+      res.header('Content-Type', 'text/plain')
+      res.status(200).send(decryptedData)
     } else {
       res.status(result.status.httpStatus).send(result.status.error)
     }

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -45,6 +45,9 @@ providerRoutes.post('/encrypt', async (req, res) => {
     })
     if (result.stream) {
       const encryptedData = await streamToString(result.stream as Readable)
+      // There is an issue here with the format of the response
+      // Error: invalid arrayify value.. on setMetadata()
+      // when using Ocean CLI to publish encrypted asset)
       res.status(200).send(encryptedData)
     } else {
       res.status(result.status.httpStatus).send(result.status.error)

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -45,9 +45,7 @@ providerRoutes.post('/encrypt', async (req, res) => {
     })
     if (result.stream) {
       const encryptedData = await streamToString(result.stream as Readable)
-      // There is an issue here with the format of the response
-      // Error: invalid arrayify value.. on setMetadata()
-      // when using Ocean CLI to publish encrypted asset)
+      res.header('Content-Type', 'application/octet-stream')
       res.status(200).send(encryptedData)
     } else {
       res.status(result.status.httpStatus).send(result.status.error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ if (config.hasIndexer && dbconn) {
   // if we set this var
   // it also loads initial data (useful for testing, or we might actually want to have a bootstrap list)
   // store and advertise DDOs
-  if (process.env.LOAD_INITIAL_DDOS) {
+  if (process.env.LOAD_INITIAL_DDOS && config.hasP2P) {
     const list = loadInitialDDOS()
     if (list.length > 0) {
       // we need a timeout here, otherwise we have no peers available

--- a/src/test/integration/completeFlow.test.ts
+++ b/src/test/integration/completeFlow.test.ts
@@ -244,8 +244,8 @@ describe('Should run a complete node flow.', () => {
 
     genericAsset.services[0].files = encryptedData
 
-    const metadata = hexlify(Buffer.from(JSON.stringify(genericAsset)))
-    const documentHash = '0x' + createHash('sha256').update(metadata).digest('hex')
+    const documentHash =
+      '0x' + createHash('sha256').update(JSON.stringify(genericAsset)).digest('hex')
 
     const genericAssetData = Uint8Array.from(Buffer.from(JSON.stringify(genericAsset)))
     const encryptedDDO = await encrypt(genericAssetData, 'ECIES')

--- a/src/test/integration/completeFlow.test.ts
+++ b/src/test/integration/completeFlow.test.ts
@@ -44,6 +44,11 @@ import {
   tearDownEnvironment
 } from '../utils/utils.js'
 import { FileInfoHandler } from '../../components/core/fileInfoHandler.js'
+import {
+  DEVELOPMENT_CHAIN_ID,
+  getOceanArtifactsAdresses,
+  getOceanArtifactsAdressesByChainId
+} from '../../utils/address.js'
 
 describe('Should run a complete node flow.', () => {
   let config: OceanNodeConfig
@@ -96,14 +101,10 @@ describe('Should run a complete node flow.', () => {
 
     indexer = new OceanIndexer(database, mockSupportedNetworks)
 
-    const data = JSON.parse(
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
-      fs.readFileSync(
-        process.env.ADDRESS_FILE ||
-          `${homedir}/.ocean/ocean-contracts/artifacts/address.json`,
-        'utf8'
-      )
-    )
+    let network = getOceanArtifactsAdressesByChainId(DEVELOPMENT_CHAIN_ID)
+    if (!network) {
+      network = getOceanArtifactsAdresses().development
+    }
 
     provider = new JsonRpcProvider('http://127.0.0.1:8545')
 
@@ -114,7 +115,7 @@ describe('Should run a complete node flow.', () => {
 
     genericAsset = genericDDO
     factoryContract = new ethers.Contract(
-      data.development.ERC721Factory,
+      network.ERC721Factory,
       ERC721Factory.abi,
       publisherAccount
     )

--- a/src/test/integration/download.test.ts
+++ b/src/test/integration/download.test.ts
@@ -17,10 +17,14 @@ import { Database } from '../../components/database/index.js'
 import { OceanIndexer } from '../../components/Indexer/index.js'
 import { RPCS } from '../../@types/blockchain.js'
 import { genericDDO } from '../data/ddo.js'
-import { getOceanArtifactsAdresses } from '../../utils/address.js'
+import {
+  DEVELOPMENT_CHAIN_ID,
+  getOceanArtifactsAdresses,
+  getOceanArtifactsAdressesByChainId
+} from '../../utils/address.js'
 import { DownloadHandler } from '../../components/core/downloadHandler.js'
 import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20TemplateEnterprise.sol/ERC20TemplateEnterprise.json' assert { type: 'json' }
-import { getEventFromTx, sleep } from '../../utils/util.js'
+import { getEventFromTx } from '../../utils/util.js'
 import { waitToIndex, delay } from './testUtils.js'
 import { getConfiguration } from '../../utils/config.js'
 import { ProviderFeeData } from '../../@types/Fees.js'
@@ -74,7 +78,10 @@ describe('Download Tests', () => {
     database = await new Database(dbConfig)
     indexer = new OceanIndexer(database, mockSupportedNetworks)
 
-    const data = getOceanArtifactsAdresses()
+    let network = getOceanArtifactsAdressesByChainId(DEVELOPMENT_CHAIN_ID)
+    if (!network) {
+      network = getOceanArtifactsAdresses().development
+    }
 
     provider = new JsonRpcProvider('http://127.0.0.1:8545')
     consumerAccount = (await provider.getSigner(1)) as Signer
@@ -83,7 +90,7 @@ describe('Download Tests', () => {
     consumerAddress = await consumerAccount.getAddress()
     genericAsset = genericDDO
     factoryContract = new ethers.Contract(
-      data.development.ERC721Factory,
+      network.ERC721Factory,
       ERC721Factory.abi,
       publisherAccount
     )

--- a/src/test/integration/encryptDecryptDDO.test.ts
+++ b/src/test/integration/encryptDecryptDDO.test.ts
@@ -11,7 +11,11 @@ import { assert, expect } from 'chai'
 import { getEventFromTx, streamToString } from '../../utils/util.js'
 import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json' assert { type: 'json' }
 import { RPCS } from '../../@types/blockchain.js'
-import { getOceanArtifactsAdresses } from '../../utils/address.js'
+import {
+  DEVELOPMENT_CHAIN_ID,
+  getOceanArtifactsAdresses,
+  getOceanArtifactsAdressesByChainId
+} from '../../utils/address.js'
 import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json' assert { type: 'json' }
 import { genericDDO } from '../data/ddo.js'
 import { createHash } from 'crypto'
@@ -60,13 +64,17 @@ describe('Should encrypt and decrypt DDO', () => {
   let previousConfiguration: OverrideEnvConfig[]
 
   before(async () => {
-    const artifactsAddresses = getOceanArtifactsAdresses()
+    let artifactsAddresses = getOceanArtifactsAdressesByChainId(DEVELOPMENT_CHAIN_ID)
+    if (!artifactsAddresses) {
+      artifactsAddresses = getOceanArtifactsAdresses().development
+    }
+
     provider = new JsonRpcProvider('http://127.0.0.1:8545')
     publisherAccount = (await provider.getSigner(0)) as Signer
     publisherAddress = await publisherAccount.getAddress()
     genericAsset = genericDDO
     factoryContract = new ethers.Contract(
-      artifactsAddresses.development.ERC721Factory,
+      artifactsAddresses.ERC721Factory,
       ERC721Factory.abi,
       publisherAccount
     )

--- a/src/test/integration/encryptDecryptDDO.test.ts
+++ b/src/test/integration/encryptDecryptDDO.test.ts
@@ -147,8 +147,8 @@ describe('Should encrypt and decrypt DDO', () => {
     genericAsset.nftAddress = dataNftAddress
     genericAsset.services[0].datatokenAddress = datatokenAddress
 
-    const metadata = hexlify(Buffer.from(JSON.stringify(genericAsset)))
-    documentHash = '0x' + createHash('sha256').update(metadata).digest('hex')
+    documentHash =
+      '0x' + createHash('sha256').update(JSON.stringify(genericAsset)).digest('hex')
 
     const genericAssetData = Uint8Array.from(Buffer.from(JSON.stringify(genericAsset)))
     const encryptedData = await encrypt(genericAssetData, 'ECIES')
@@ -283,6 +283,7 @@ describe('Should encrypt and decrypt DDO', () => {
       transactionId: txReceiptEncryptDDO.hash,
       dataNftAddress,
       nonce: Date.now().toString(),
+      documentHash,
       signature: '0x123'
     }
     const response = await new DecryptDdoHandler(oceanNode).handle(decryptDDOTask)

--- a/src/test/integration/indexer.test.ts
+++ b/src/test/integration/indexer.test.ts
@@ -21,7 +21,11 @@ import { RPCS } from '../../@types/blockchain.js'
 import { getEventFromTx } from '../../utils/util.js'
 import { delay, waitToIndex, signMessage } from './testUtils.js'
 import { genericDDO } from '../data/ddo.js'
-import { getOceanArtifactsAdresses } from '../../utils/address.js'
+import {
+  DEVELOPMENT_CHAIN_ID,
+  getOceanArtifactsAdresses,
+  getOceanArtifactsAdressesByChainId
+} from '../../utils/address.js'
 import { createFee } from '../../components/core/utils/feesHandler.js'
 import { DDO } from '../../@types/DDO/DDO.js'
 import { getMockSupportedNetworks } from '../utils/utils.js'
@@ -71,14 +75,17 @@ describe('Indexer stores a new metadata events and orders.', () => {
     database = await new Database(dbConfig)
     indexer = new OceanIndexer(database, mockSupportedNetworks)
 
-    const data = getOceanArtifactsAdresses()
+    let artifactsAddresses = getOceanArtifactsAdressesByChainId(DEVELOPMENT_CHAIN_ID)
+    if (!artifactsAddresses) {
+      artifactsAddresses = getOceanArtifactsAdresses().development
+    }
 
     provider = new JsonRpcProvider('http://127.0.0.1:8545')
     publisherAccount = (await provider.getSigner(0)) as Signer
     consumerAccount = (await provider.getSigner(1)) as Signer
     genericAsset = genericDDO
     factoryContract = new ethers.Contract(
-      data.development.ERC721Factory,
+      artifactsAddresses.ERC721Factory,
       ERC721Factory.abi,
       publisherAccount
     )

--- a/src/test/integration/transactionValidation.test.ts
+++ b/src/test/integration/transactionValidation.test.ts
@@ -12,8 +12,6 @@ import {
   ZeroAddress
 } from 'ethers'
 import { createHash } from 'crypto'
-import fs from 'fs'
-import { homedir } from 'os'
 import { validateOrderTransaction } from '../../components/core/validateTransaction.js'
 import ERC721Factory from '@oceanprotocol/contracts/artifacts/contracts/ERC721Factory.sol/ERC721Factory.json' assert { type: 'json' }
 import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json' assert { type: 'json' }
@@ -22,7 +20,11 @@ import { getEventFromTx } from '../../utils/util.js'
 import { delay, signMessage, waitToIndex } from './testUtils.js'
 import { genericDDO } from '../data/ddo.js'
 import { Database } from '../../components/database/index.js'
-import { getOceanArtifactsAdresses } from '../../utils/address.js'
+import {
+  DEVELOPMENT_CHAIN_ID,
+  getOceanArtifactsAdresses,
+  getOceanArtifactsAdressesByChainId
+} from '../../utils/address.js'
 import { createFee } from '../../components/core/utils/feesHandler.js'
 import { DDO } from '../../@types/DDO/DDO.js'
 
@@ -68,7 +70,10 @@ describe('validateOrderTransaction Function with Orders', () => {
     publisherAddress = await publisherAccount.getAddress()
     consumerAddress = await consumerAccount.getAddress()
 
-    const data = getOceanArtifactsAdresses()
+    let artifactsAddresses = getOceanArtifactsAdressesByChainId(DEVELOPMENT_CHAIN_ID)
+    if (!artifactsAddresses) {
+      artifactsAddresses = getOceanArtifactsAdresses().development
+    }
 
     const dbConfig = {
       url: 'http://localhost:8108/?apiKey=xyz'
@@ -77,7 +82,7 @@ describe('validateOrderTransaction Function with Orders', () => {
 
     // Initialize the factory contract
     factoryContract = new ethers.Contract(
-      data.development.ERC721Factory,
+      artifactsAddresses.ERC721Factory,
       ERC721Factory.abi,
       publisherAccount
     )

--- a/src/test/unit/indexer/utils.test.ts
+++ b/src/test/unit/indexer/utils.test.ts
@@ -15,9 +15,11 @@ import {
 
 describe('Utils', () => {
   let provider: ethers.JsonRpcProvider
+  let signer: ethers.Wallet
 
   before(async () => {
     provider = new ethers.JsonRpcProvider('https://rpc-mumbai.maticvigil.com')
+    signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
   })
 
   it('should get deployed contract block', async () => {
@@ -33,7 +35,13 @@ describe('Utils', () => {
   it('should process blocks', async () => {
     const startIndex = 100
     const count = 5
-    const processedBlocks = await processBlocks(provider, 80001, startIndex, count)
+    const processedBlocks = await processBlocks(
+      signer,
+      provider,
+      80001,
+      startIndex,
+      count
+    )
     expect(processedBlocks.lastBlock).to.be.a('number')
   })
 
@@ -72,6 +80,6 @@ describe('Utils', () => {
       }
     ]
 
-    await processChunkLogs(logs, provider, 80001)
+    await processChunkLogs(logs, signer, provider, 80001)
   })
 })

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { homedir } from 'os'
 import addresses from '@oceanprotocol/contracts/addresses/address.json' assert { type: 'json' }
-import { CORE_LOGGER } from './logging/common'
+import { CORE_LOGGER } from './logging/common.js'
 
 /**
  * Get the artifacts address from the address.json file

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { homedir } from 'os'
 import addresses from '@oceanprotocol/contracts/addresses/address.json' assert { type: 'json' }
+import { CORE_LOGGER } from './logging/common'
 
 /**
  * Get the artifacts address from the address.json file
@@ -17,8 +18,34 @@ export function getOceanArtifactsAdresses(): any {
     )
     return JSON.parse(data)
   } catch (error) {
+    CORE_LOGGER.error(error)
     return null
   }
 }
+
+/**
+ * Get the artifacts address from the address.json file, for the given chain
+ * either from the env or from the ocean-contracts dir, safer than above, because sometimes the network name
+ * is mispeled, best example "optimism_sepolia" vs "optimism-sepolia"
+ * @returns data or null
+ */
+export function getOceanArtifactsAdressesByChainId(chain: number): any {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const data = getOceanArtifactsAdresses()
+    if (data) {
+      const networks = Object.keys(data)
+      for (const network of networks) {
+        if (data[network].chainId === chain) {
+          return data[network]
+        }
+      }
+    }
+  } catch (error) {
+    CORE_LOGGER.error(error)
+  }
+  return null
+}
 // default token addresses per chain
 export const OCEAN_ARTIFACTS_ADDRESSES_PER_CHAIN = addresses
+export const DEVELOPMENT_CHAIN_ID = 8996

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -8,7 +8,7 @@ export class Blockchain {
   public constructor(rpc: string, chaindId: number) {
     this.chainId = chaindId
     this.provider = new ethers.JsonRpcProvider(rpc)
-    this.signer = new ethers.Wallet(process.env.PRIVATE_KEY.substring(2))
+    this.signer = new ethers.Wallet(process.env.PRIVATE_KEY, this.provider)
   }
 
   public getSigner(): Signer {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,4 @@
 import { Hashes } from '../@types/blockchain'
-import { DDO } from '../@types/DDO/DDO'
-import { ArweaveFileObject, IpfsFileObject, UrlFileObject } from '../@types/fileObject'
-import { P2PCommandResponse } from '../@types/OceanNode'
 
 // Add all the supported commands
 export const PROTOCOL_COMMANDS = {


### PR DESCRIPTION
Fixes #251 

Changes proposed in this PR:

- fix publish DDO (with or without encryption)
- no account ( provider.getSigner()) throwing the error
- no advertiseDOO (no event data)
- refactor repeated code, use constants instead of hardcoded str
- fix reading addresses for "sepolia optimism" 
- fix getSigner() - Use blockchain class method
- fix tests

This:
`npm run cli publish metadata/simpleDownloadDataset false ` does not give any error,
but on the ocean node side it is not working anymore
it fails with:
` message: '[INDEXER] => Error processMetadataEvents: Error: no such account',` when we try `provider.getSigner()`
And from there it cascades a few other errors