### PR TITLE
Integration test fix - running all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done
       - name: integration tests
-        run: npm run test:integration:complete
+        run: npm run test:integration:cover
         env:
           OPERATOR_SERVICE_URL: '["http://172.15.0.13:31000/"]'
           PRIVATE_KEY: ${{ secrets.NODE1_PRIVATE_KEY }}


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- Integration test fix - running all tests
- using `test:integration:cover` rather than `test:integration:complete`
