### PR TITLE
Command for light integration tests no compute to data

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Now, back in your nodes terminal, you can run the tests
 npm run test:integration
 ```
 
-If you started barge without c2d components you can run a lighter version of integration tests that do no run the compute to data tests.
+If you started barge without c2d components you can run a lighter version of integration tests that do not run the compute to data tests.
 
 ```bash
 npm run test:integration-light

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Now, back in your nodes terminal, you can run the tests
 npm run test:integration
 ```
 
+If you started barge without c2d components you can run a lighter version of integration tests that do no run the compute to data tests.
+
+```bash
+npm run test:integration-light
+```
+
 ## Unit and integration .environments
 
 Whenever possible, we should avoid overriding .env variables, as it might affect local configuration and other tests

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ npm run test:integration
 If you started barge without c2d components you can run a lighter version of integration tests that do not run the compute to data tests.
 
 ```bash
-npm run test:integration-light
+npm run test:integration:light
 ```
 
 ## Unit and integration .environments

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "npm run lint && npm run test:unit:cover && npm run test:integration:cover",
     "test:unit": "npm run build-tests && npm run mocha \"./dist/test/unit/**/*.test.js\"",
     "test:integration": "npm run build-tests && npm run mocha \"./dist/test/integration/**/*.test.js\"",
-    "test:integration-light": "npm run build-tests && npm run mocha-light \"./dist/test/integration/**/*.test.js\"",
+    "test:integration:light": "npm run build-tests && npm run mocha-light \"./dist/test/integration/**/*.test.js\"",
     "test:unit:cover": "nyc --report-dir coverage/unit npm run test:unit",
     "test:integration:cover": "nyc --report-dir coverage/integration --no-clean npm run test:integration",
     "logs": "./scripts/logs.sh"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "type-check": "tsc --noEmit",
     "check-nonce": "npm run build && node dist/helpers/scripts/checkNonceTracking.js",
     "mocha": "mocha --node-env=test --config .mocharc.json",
+    "mocha-light": "mocha --node-env=test --config .mocharc.json --exclude \"./dist/test/integration/compute.test.js\"",
     "test": "npm run lint && npm run test:unit:cover && npm run test:integration:cover",
     "test:unit": "npm run build-tests && npm run mocha \"./dist/test/unit/**/*.test.js\"",
     "test:integration": "npm run build-tests && npm run mocha \"./dist/test/integration/**/*.test.js\"",
+    "test:integration-light": "npm run build-tests && npm run mocha-light \"./dist/test/integration/**/*.test.js\"",
     "test:unit:cover": "nyc --report-dir coverage/unit npm run test:unit",
     "test:integration:cover": "nyc --report-dir coverage/integration --no-clean npm run test:integration",
     "logs": "./scripts/logs.sh"


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- added mocha-light command to run the test suites excluding compute file
- added new light integration test command that calls the mocha-light command
- added readme note

local run without the compute test suite
<img width="346" alt="Screenshot 2024-04-12 at 10 44 53" src="https://github.com/oceanprotocol/ocean-node/assets/13447142/c2485b4d-7bbe-4e3b-ba4d-1de67bb87df3">
