### PR TITLE
Unit tests - have minimal .env even before root hook get called (no setup needed)

### DIFF
--- a/src/test/.env.test
+++ b/src/test/.env.test
@@ -2,7 +2,7 @@ HTTP_API_PORT=8001
 P2P_ipV4BindTcpPort=8000
 PRIVATE_KEY=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
 RPCS='{ "8996": {"rpc": "http://127.0.0.1:8545", "chainId": 8996, "network": "development", "chunkSize": 100}}'
-DB_URL=http://172.15.0.6:8108?apiKey=xyz
+DB_URL=http://localhost:8108?apiKey=xyz
 IPFS_GATEWAY=https://ipfs.io/
 ARWEAVE_GATEWAY=https://arweave.net/
 NODE1_PRIVATE_KEY=0xcb345bd2b11264d523ddaf383094e2675c420a17511c3102a53817f13474a7ff

--- a/src/test/utils/hooks.ts
+++ b/src/test/utils/hooks.ts
@@ -18,7 +18,7 @@ import {
 // save any existing configuration before starting the tests
 const initialConfiguration: Map<string, OverrideEnvConfig> = getExistingEnvironment()
 let envOverrides: OverrideEnvConfig[] = []
-
+let initialSetupDone = false
 // if you want to override some variables, just use the
 // OverrideEnvConfig type and build an array to pass to setupEnvironment() (on before() function)
 // this function returns the new configuration together with any variables that were overrided
@@ -52,6 +52,7 @@ export const mochaHooks = {
     setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides).then((overrides) => {
       envOverrides = overrides
     })
+    initialSetupDone = true
 
     // just in case the configuration value fails
     this.timeout(DEFAULT_TEST_TIMEOUT)
@@ -74,3 +75,12 @@ export const mochaHooks = {
     })
   }
 }
+// some test code might call getConfiguration() before the beforeAll() hook gets called (before actual tests)
+// if that happens we might not have any inital env vars yet, that are mandatory (like PRIVATE_KEY)
+// so we need to make sure that we have the basics in place
+async function doInitialSetup() {
+  if (!initialSetupDone) {
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, getEnvOverrides())
+  }
+}
+await doInitialSetup()


### PR DESCRIPTION
Fixes #393 .

Changes proposed in this PR:

- Unit tests require some .env setup (they do not run out of the box without env) like integration ones (specially locally)
- This is because there are some calls (on some test files) to getConfiguration() before the mocha root hooks get called..
- As a result, there could be missing required variables (like PRIVATE_KEY) since the env setup will not be done in time
- This situation is addressed on this PR, and we make sure we have the basic/required .env stuff before running the suite

With this change we can run unit tests locally, without even have anything configured