### PR TITLE
Issue 396 warn dev artifacts

### DIFF
--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -40,6 +40,15 @@ export function getOceanArtifactsAdressesByChainId(chain: number): any {
         }
       }
     }
+    // just warn about this missing configuration if running locally
+    if (
+      chain === DEVELOPMENT_CHAIN_ID &&
+      !existsEnvironmentVariable(ENVIRONMENT_VARIABLES.ADDRESS_FILE, true)
+    ) {
+      CORE_LOGGER.warn(
+        'Cannot find artifacts addresses for "development" chain, unless "ADDRESS_FILE" is configured!'
+      )
+    }
   } catch (error) {
     CORE_LOGGER.error(error)
   }

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -46,7 +46,7 @@ export function getOceanArtifactsAdressesByChainId(chain: number): any {
       !existsEnvironmentVariable(ENVIRONMENT_VARIABLES.ADDRESS_FILE, true)
     ) {
       CORE_LOGGER.warn(
-        'Cannot find artifacts addresses for "development" chain, unless "ADDRESS_FILE" is configured!'
+        'Cannot find contract artifacts addresses for "development" chain. Please set the "ADDRESS_FILE" environmental variable!'
       )
     }
   } catch (error) {


### PR DESCRIPTION
Fixes #396 .

Changes proposed in this PR:

- Just warn/log helper message, if we are looking for artifacts addresses for 'development' chain without having set '`ADDRESS_FILE`' (basically we will not have indexing tasks if we forget this config while running locally)