### PR TITLE
Docker image size reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/node_modules/ /usr/src/app/node_modules/
 RUN npm run build
+# Remove the dashboard folder to reduce the image size and avoid shipping development files
 RUN rm -rf dashboard
 ENV P2P_ipV4BindTcpPort=9000
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/node_modules/ /usr/src/app/node_modules/
 RUN npm run build
+RUN rm -rf dashboard
 ENV P2P_ipV4BindTcpPort=9000
 EXPOSE 9000
 ENV P2P_ipV4BindWsPort=9001


### PR DESCRIPTION
Fixes #410 

Changes proposed in this PR:

- Removing the dashboard development files from the docker image. Once the dashboard has been built into the static files, the development files (including a very large node modules folder) are not needed for anything. 

Before the dashboard development files are deleted, we have: 

```Bash
$ du -c -s -h *
28K	API.md
1.6G	dashboard
44K	data
6.1M	dist
4.0K	Dockerfile
120K	docs
16K	env.md
12K	LICENSE
69M	logs
784M	node_modules
8.0K	package.json
668K	package-lock.json
12K	README.md
60K	schemas
8.0K	scripts
1.4M	src
4.0K	tsconfig.json
4.0K	tsoa.json
4.0K	typesense-compose.yml
236K	typesense-data
2.4G	total
```

After the dashboard development files are deleted we have: 

```bash
$ du -c -s -h *
28K	API.md
44K	data
6.1M	dist
4.0K	Dockerfile
120K	docs
16K	env.md
12K	LICENSE
69M	logs
784M	node_modules
8.0K	package.json
668K	package-lock.json
12K	README.md
60K	schemas
8.0K	scripts
1.4M	src
4.0K	tsconfig.json
4.0K	tsoa.json
4.0K	typesense-compose.yml
236K	typesense-data
861M	total
```