### PR TITLE
Fix compute http routes

### DIFF
--- a/src/components/core/handler/handler.ts
+++ b/src/components/core/handler/handler.ts
@@ -23,7 +23,7 @@ export interface RequestDataCheck {
 export abstract class Handler implements ICommandHandler {
   private nodeInstance?: OceanNode
   private requestMap: Map<string, RequestLimiter>
-  public constructor(oceanNode?: OceanNode) {
+  public constructor(oceanNode: OceanNode) {
     this.nodeInstance = oceanNode
     this.requestMap = new Map<string, RequestLimiter>()
   }

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -34,7 +34,9 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeEnvironments`, async (req, r
       chainId: parseInt(req.query.chainId as string),
       node: (req.query.node as string) || null
     }
-    const response = await new ComputeGetEnvironmentsHandler().handle(getEnvironmentsTask) // get compute environments
+    const response = await new ComputeGetEnvironmentsHandler(req.oceanNode).handle(
+      getEnvironmentsTask
+    ) // get compute environments
     const computeEnvironments = await streamToObject(response.stream as Readable)
 
     // check if computeEnvironments is a valid json object and not empty
@@ -75,7 +77,7 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/compute`, async (req, res) => {
       startComputeTask.output = req.query.output as ComputeOutput
     }
 
-    const response = await new ComputeStartHandler().handle(startComputeTask) // get compute environments
+    const response = await new ComputeStartHandler(req.oceanNode).handle(startComputeTask) // get compute environments
     const jobs = await streamToObject(response.stream as Readable)
     res.status(200).json(jobs)
   } catch (error) {
@@ -99,7 +101,7 @@ computeRoutes.put(`${SERVICES_API_BASE_PATH}/compute`, async (req, res) => {
       nonce: (req.query.nonce as string) || null,
       jobId: (req.query.jobId as string) || null
     }
-    const response = await new ComputeStopHandler().handle(stopComputeTask)
+    const response = await new ComputeStopHandler(req.oceanNode).handle(stopComputeTask)
     const jobs = await streamToObject(response.stream as Readable)
     res.status(200).json(jobs)
   } catch (error) {
@@ -121,7 +123,9 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/compute`, async (req, res) => {
       did: (req.query.did as string) || null,
       jobId: (req.query.jobId as string) || null
     }
-    const response = await new ComputeGetStatusHandler().handle(statusComputeTask)
+    const response = await new ComputeGetStatusHandler(req.oceanNode).handle(
+      statusComputeTask
+    )
     const jobs = await streamToObject(response.stream as Readable)
     res.status(200).json(jobs)
   } catch (error) {
@@ -146,7 +150,9 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeResult`, async (req, res) =>
       nonce: (req.query.nonce as string) || null
     }
 
-    const response = await new ComputeGetResultHandler().handle(resultComputeTask)
+    const response = await new ComputeGetResultHandler(req.oceanNode).handle(
+      resultComputeTask
+    )
     if (response.stream) {
       res.status(response.status.httpStatus)
       res.set(response.status.headers)


### PR DESCRIPTION
Fixes #442  .

Changes proposed in this PR:

- add oceanNode to http routes for c2d
- make oceanNode mandatory
```console
message: '[HTTP] => [HTTP] => GET computeEnvironments request received with query: {}',
  timestamp: '2024-05-15 11:45:37'
}
{
  component: 'HTTP',
  moduleName: 'HTTP',
  level: 'error',
  message: "Error: TypeError: Cannot read properties of undefined (reading 'getRemoteCaller')",
```