### PR TITLE
Fix: dashboard failing build if NODE_ENV is changed

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NODE_ENV=production  next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:no-dashboard": "npm run clean && npm run build:tsc",
     "build:tsc": "tsc --sourceMap",
     "build-tests:tsc": "tsc --sourceMap --sourceRoot ./src/test && cp ./src/test/.env.test ./dist/test",
-    "build:dashboard": "cd dashboard && npm install && npx next build",
+    "build:dashboard": "cd dashboard && npm install && NODE_ENV=production npx next build",
     "client": "mkdir -p ./dist/helpers/scripts/output && node dist/helpers/scripts/clientExample.js",
     "clean": "rm -rf ./dist/ ./doc/ ./.nyc_output",
     "build-tests": "rm -rf ./dist/test && npm run build-tests:tsc",


### PR DESCRIPTION
Fixes #448 

Changes proposed in this PR:

- Ensuring that NODE_ENV is always production for the dashboard build