### PR TITLE
Fix DecryptDdoHandler

### DIFF
--- a/src/components/core/handler/ddoHandler.ts
+++ b/src/components/core/handler/ddoHandler.ts
@@ -204,7 +204,10 @@ export class DecryptDdoHandler extends Handler {
             data: receipt.logs[0].data
           }
           const eventData = abiInterface.parseLog(eventObject)
-          if (eventData.name !== EVENTS.METADATA_CREATED) {
+          if (
+            eventData.name !== EVENTS.METADATA_CREATED &&
+            eventData.name !== EVENTS.METADATA_UPDATED
+          ) {
             throw new Error(`event name ${eventData.name}`)
           }
           flags = parseInt(eventData.args[3], 16)


### PR DESCRIPTION
Fixes edit DDO

When DDO metadata was updated, it was not updated in ocean-node