### PR TITLE
Fix FileInfoHandler

### DIFF
--- a/src/components/core/handler/fileInfoHandler.ts
+++ b/src/components/core/handler/fileInfoHandler.ts
@@ -38,8 +38,9 @@ async function getFile(
       throw new Error(msg)
     }
     // 3. Decrypt the url
+    const files = service.files.startsWith('0x') ? service.files.slice(2) : service.files
     const decryptedUrlBytes = await decrypt(
-      Uint8Array.from(Buffer.from(service.files, 'hex')),
+      Uint8Array.from(Buffer.from(files, 'hex')),
       EncryptMethod.ECIES
     )
     CORE_LOGGER.logMessage(`URL decrypted for Service ID: ${serviceId}`)
@@ -62,10 +63,10 @@ async function formatMetadata(file: ArweaveFileObject | IpfsFileObject | UrlFile
     file.type === 'url'
       ? (file as UrlFileObject).url
       : file.type === 'arweave'
-      ? urlJoin(process.env.ARWEAVE_GATEWAY, (file as ArweaveFileObject).transactionId)
-      : file.type === 'ipfs'
-      ? (file as IpfsFileObject).hash
-      : null
+        ? urlJoin(process.env.ARWEAVE_GATEWAY, (file as ArweaveFileObject).transactionId)
+        : file.type === 'ipfs'
+          ? (file as IpfsFileObject).hash
+          : null
 
   const { contentLength, contentType, contentChecksum } = await fetchFileMetadata(
     url,
@@ -121,10 +122,10 @@ export class FileInfoHandler extends Handler {
           task.type === 'url'
             ? new UrlStorage(task.file as UrlFileObject)
             : task.type === 'arweave'
-            ? new ArweaveStorage(task.file as ArweaveFileObject)
-            : task.type === 'ipfs'
-            ? new IpfsStorage(task.file as IpfsFileObject)
-            : null
+              ? new ArweaveStorage(task.file as ArweaveFileObject)
+              : task.type === 'ipfs'
+                ? new IpfsStorage(task.file as IpfsFileObject)
+                : null
 
         fileInfo = await storage.getFileInfo({
           type: task.type,

--- a/src/components/core/handler/fileInfoHandler.ts
+++ b/src/components/core/handler/fileInfoHandler.ts
@@ -63,10 +63,10 @@ async function formatMetadata(file: ArweaveFileObject | IpfsFileObject | UrlFile
     file.type === 'url'
       ? (file as UrlFileObject).url
       : file.type === 'arweave'
-        ? urlJoin(process.env.ARWEAVE_GATEWAY, (file as ArweaveFileObject).transactionId)
-        : file.type === 'ipfs'
-          ? (file as IpfsFileObject).hash
-          : null
+      ? urlJoin(process.env.ARWEAVE_GATEWAY, (file as ArweaveFileObject).transactionId)
+      : file.type === 'ipfs'
+      ? (file as IpfsFileObject).hash
+      : null
 
   const { contentLength, contentType, contentChecksum } = await fetchFileMetadata(
     url,
@@ -122,10 +122,10 @@ export class FileInfoHandler extends Handler {
           task.type === 'url'
             ? new UrlStorage(task.file as UrlFileObject)
             : task.type === 'arweave'
-              ? new ArweaveStorage(task.file as ArweaveFileObject)
-              : task.type === 'ipfs'
-                ? new IpfsStorage(task.file as IpfsFileObject)
-                : null
+            ? new ArweaveStorage(task.file as ArweaveFileObject)
+            : task.type === 'ipfs'
+            ? new IpfsStorage(task.file as IpfsFileObject)
+            : null
 
         fileInfo = await storage.getFileInfo({
           type: task.type,


### PR DESCRIPTION
Fixes decrypt function in fileInfoHandler.

The "0x" prefix is not recognized by the Buffer.from method with the 'hex' encoding.