### PR TITLE
hide raw data on logging, when checking command data

### DIFF
--- a/src/components/core/compute/initialize.ts
+++ b/src/components/core/compute/initialize.ts
@@ -49,10 +49,12 @@ export class ComputeInitializeHandler extends Handler {
   }
 
   async handle(task: ComputeInitializeCommand): Promise<P2PCommandResponse> {
+    console.log('BEFORE: ', task)
     const validationResponse = await this.verifyParamsAndRateLimits(task)
     if (this.shouldDenyTaskHandling(validationResponse)) {
       return validationResponse
     }
+    console.log('AFTER: ', task)
 
     try {
       let foundValidCompute = null

--- a/src/components/httpRoutes/validateCommands.ts
+++ b/src/components/httpRoutes/validateCommands.ts
@@ -39,9 +39,13 @@ export function validateCommandParameters(
   }
 
   const logCommandData = commandData
+
   if (commandStr === PROTOCOL_COMMANDS.ENCRYPT) {
-    logCommandData.files = [] // hide files data for logging
+    logCommandData.files = [] // hide files data (sensitive) + rawData (long buffer) from logging
+  } else if (commandStr === PROTOCOL_COMMANDS.ENCRYPT_FILE && commandData.rawData) {
+    logCommandData.rawData = []
   }
+
   CORE_LOGGER.info(
     `Checking received command data for Command "${commandStr}": ${JSON.stringify(
       logCommandData,

--- a/src/components/httpRoutes/validateCommands.ts
+++ b/src/components/httpRoutes/validateCommands.ts
@@ -46,6 +46,10 @@ export function validateCommandParameters(
     logCommandData.rawData = []
   }
 
+  if (commandStr === PROTOCOL_COMMANDS.COMPUTE_INITIALIZE) {
+    logCommandData.consumerAddress = 'FAKE'
+  }
+
   CORE_LOGGER.info(
     `Checking received command data for Command "${commandStr}": ${JSON.stringify(
       logCommandData,

--- a/src/components/httpRoutes/validateCommands.ts
+++ b/src/components/httpRoutes/validateCommands.ts
@@ -38,16 +38,13 @@ export function validateCommandParameters(
     return buildInvalidRequestMessage(`Invalid or unrecognized command: "${commandStr}"`)
   }
 
-  const logCommandData = commandData
+  // deep copy
+  const logCommandData = structuredClone(commandData)
 
   if (commandStr === PROTOCOL_COMMANDS.ENCRYPT) {
     logCommandData.files = [] // hide files data (sensitive) + rawData (long buffer) from logging
   } else if (commandStr === PROTOCOL_COMMANDS.ENCRYPT_FILE && commandData.rawData) {
     logCommandData.rawData = []
-  }
-
-  if (commandStr === PROTOCOL_COMMANDS.COMPUTE_INITIALIZE) {
-    logCommandData.consumerAddress = 'FAKE'
   }
 
   CORE_LOGGER.info(


### PR DESCRIPTION
Fixes #472 .

Changes proposed in this PR:

- hide rawData on ENCRYPT_FILE command  from logging (can be a huge buffer)
- deep copy with `structuredClone`
