### PR TITLE
fix operator service call to getResult (not computeResult) + signature message mismatches

### DIFF
--- a/src/components/c2d/compute_engines.ts
+++ b/src/components/c2d/compute_engines.ts
@@ -352,9 +352,11 @@ export class C2DEngineOPFK8 extends C2DEngine {
   ): Promise<Readable> {
     const nonce: number = new Date().getTime()
     const config = await getConfiguration()
-    let message: string
-    if (jobId) message = String(nonce + consumerAddress + jobId)
-    else message = String(nonce + consumerAddress + jobId)
+    // signature check on operator service is only owner + jobId
+    // nonce is not part of signature message
+    const message: string = jobId
+      ? String(consumerAddress + jobId)
+      : String(consumerAddress)
     const providerSignature = await sign(message, config.keys.privateKey)
 
     const payload: OPFK8ComputeGetResult = {
@@ -370,7 +372,7 @@ export class C2DEngineOPFK8 extends C2DEngine {
         method: 'get',
         url: `${URLUtils.sanitizeURLPath(
           this.getC2DConfig().url
-        )}api/v1/operator/computeResult`,
+        )}api/v1/operator/getResult`,
         data: payload,
         responseType: 'stream'
       })

--- a/src/components/core/compute/getResults.ts
+++ b/src/components/core/compute/getResults.ts
@@ -26,7 +26,7 @@ export class ComputeGetResultHandler extends Handler {
           'Parameter : "consumerAddress" is not a valid web3 address'
         )
       }
-      if (isNaN(command.index) || command.index < 1) {
+      if (isNaN(command.index) || command.index < 0) {
         return buildInvalidRequestMessage('Invalid result index')
       }
     }

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -174,7 +174,7 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeResult`, async (req, res) =>
       command: PROTOCOL_COMMANDS.COMPUTE_GET_RESULT,
       node: (req.query.node as string) || null,
       consumerAddress: (req.query.consumerAddress as string) || null,
-      index: parseInt(req.query.index as string) || null,
+      index: req.query.index ? Number(req.query.index) : null, // can't be parseInt() because that excludes index 0
       jobId: (req.query.jobId as string) || null,
       signature: (req.query.signature as string) || null,
       nonce: (req.query.nonce as string) || null


### PR DESCRIPTION
Fixes #514 

Changes proposed in this PR:

- The url is `getResult` not `computeResult` and the nonce is not part of the signature message
- index fix
- 