### PR TITLE
pass the headers back to client request

### DIFF
--- a/src/components/core/compute/getResults.ts
+++ b/src/components/core/compute/getResults.ts
@@ -98,7 +98,7 @@ export class ComputeGetResultHandler extends Handler {
       }
       // need to pass the headers properly
       if (anyResp.headers) {
-        anyResp.status.headers = anyResp.headers
+        response.status.headers = anyResp.headers
       }
       return response
     } catch (error) {

--- a/src/components/core/compute/getResults.ts
+++ b/src/components/core/compute/getResults.ts
@@ -84,12 +84,23 @@ export class ComputeGetResultHandler extends Handler {
       }
     }
     try {
-      return {
-        stream: await engine.getComputeJobResult(task.consumerAddress, jobId, task.index),
+      const respStream = await engine.getComputeJobResult(
+        task.consumerAddress,
+        jobId,
+        task.index
+      )
+      const anyResp: any = respStream as any
+      const response: P2PCommandResponse = {
+        stream: respStream,
         status: {
           httpStatus: 200
         }
       }
+      // need to pass the headers properly
+      if (anyResp.headers) {
+        anyResp.status.headers = anyResp.headers
+      }
+      return response
     } catch (error) {
       CORE_LOGGER.error(error.message)
       return {


### PR DESCRIPTION
Fixes #521 

Changes proposed in this PR:

- pass the headers from the getResults (useful for download the proper attached file, with proper name)
- 