### PR TITLE
fix root endpoint, without RPCS

### DIFF
--- a/src/components/httpRoutes/rootEndpoint.ts
+++ b/src/components/httpRoutes/rootEndpoint.ts
@@ -7,11 +7,10 @@ export const rootEndpointRoutes = express.Router()
 rootEndpointRoutes.get('/', async (req, res) => {
   const config = await getConfiguration()
   if (!config.supportedNetworks) {
-    HTTP_LOGGER.error(`Supported networks not defined`)
-    res.status(400).send(`Supported networks not defined`)
+    HTTP_LOGGER.warn(`Supported networks not defined`)
   }
   res.json({
-    chainIds: Object.keys(config.supportedNetworks),
+    chainIds: config.supportedNetworks ? Object.keys(config.supportedNetworks) : [],
     providerAddress: config.keys.ethAddress,
     serviceEndpoints: getAllServiceEndpoints(),
     software: 'Ocean-Node',


### PR DESCRIPTION
Fixes #754

Changes proposed in this PR:

- fix root endpoint when no RPCS is set (avoid crash)
- we were trying to send the json after closing the response with a 400
- 