### PR TITLE
fix possible response with connection closed

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -557,6 +557,7 @@ export class OceanP2P extends EventEmitter {
     } catch (e) {
       response.status.httpStatus = 404
       response.status.error = 'Cannot connect to peer'
+      P2P_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Unable to connect to peer: ${peerId}`)
       return response
     }
 


### PR DESCRIPTION
Fixes #576 

Changes proposed in this PR:

- additional try/catch on `directCommand` endpoint. 
- check for connection close events
- avoid write to a closed socket
- 