### PR TITLE
updating CI to use only node v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['v20.16.0']
+        node: ['18.20.4', 'v20.16.0', 'v22.5.1']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: 'v20.16.0'
+        node: ['v20.16.0']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: ['18.20.4', 'v20.16.0']
+          node-version: 'v20.16.0'
       - name: Cache node_modules
         uses: actions/cache@v2
         env:
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['18.20.4', 'v20.16.0']
+        node: 'v20.16.0'
 
     steps:
       - uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: ['18.20.4', 'v20.16.0']
+          node-version: 'v20.16.0'
       - name: Cache node_modules
         uses: actions/cache@v2
         env:
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: ['18.20.4', 'v20.16.0']
+          node-version: 'v20.16.0'
       - name: Cache node_modules
         uses: actions/cache@v2
         env:
@@ -189,7 +189,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ['18.20.4', 'v20.16.0']
+          node-version: 'v20.16.0'
 
       - name: Cache node_modules
         uses: actions/cache@v2


### PR DESCRIPTION
Changes proposed in this PR:

- updating CI to use only node v20 for all tests except the build test
- Updating the build test to run on node v18, v20 & v22,