### PR TITLE
fix node crash on stream, node internals

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -563,7 +563,7 @@ export class OceanP2P extends EventEmitter {
     if (stream) {
       response.stream = stream
       try {
-        pipe(
+        await pipe(
           // Source data
           [uint8ArrayFromString(message)],
           // Write to the stream, and pass its output to the next function

--- a/src/test/integration/logs.test.ts
+++ b/src/test/integration/logs.test.ts
@@ -85,7 +85,7 @@ describe('LogDatabase CRUD', () => {
     const endTime = new Date() // current time
 
     // Retrieve the latest log entries
-    let logs = await database.logs.retrieveMultipleLogs(startTime, endTime, 200)
+    let logs = await database.logs.retrieveMultipleLogs(startTime, endTime, 300)
     logs = logs.filter((log) => log.message === newLogEntry.message)
 
     expect(logs?.length).to.equal(1)
@@ -459,7 +459,7 @@ describe('LogDatabase retrieveMultipleLogs with pagination', () => {
   })
 
   it('should return empty results for a non-existent page', async () => {
-    const nonExistentPage = 100 // Assuming this page doesn't exist
+    const nonExistentPage = 300 // Assuming this page doesn't exist
     const logs = await database.logs.retrieveMultipleLogs(
       new Date(Date.now() - 10000), // 10 seconds ago
       new Date(), // now


### PR DESCRIPTION
Fixes node crash on stream handling

Changes proposed in this PR:

- fix random node crash when sending remote p2p commands 
- Was on sink function (stream-to-it) module [https://github.com/alanshaw/stream-to-it/blob/bde963bfb37f3a5dc0d3e628e72a2be0e59116e0/src/sink.ts#L94](https://github.com/alanshaw/stream-to-it/blob/bde963bfb37f3a5dc0d3e628e72a2be0e59116e0/src/sink.ts#L94)
- 
example from logs:
`{"component":"CORE","date":"Thu Aug 01 2024 19:00:05 GMT+0100 (Western European Summer Time)","error":{"code":"ECONNRESET","errno":-104,"syscall":"write"},"exception":true,"level":"error","message":"uncaughtException: write ECONNRESET\nError: write ECONNRESET\n    at afterWriteDispatched (node:internal/stream_base_commons:161:15)\n    at writeGeneric (node:internal/stream_base_commons:152:3)\n    at Socket._writeGeneric (node:net:954:11)\n    at Socket._write (node:net:966:8)\n    at writeOrBuffer (node:internal/streams/writable:570:12)\n    at _write (node:internal/streams/writable:499:10)\n    at Writable.write (node:internal/streams/writable:508:10)\n    at file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/stream-to-it/dist/src/sink.js:77:31\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.sink (file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/@libp2p/tcp/dist/src/socket-to-conn.js:72:17)","os":{"loadavg":[2.57,2.24,2.06],"uptime":13275.57},"process":{"argv":["/home/paulo/.nvm/versions/node/v20.16.0/bin/node","/home/paulo/workspace/OCEAN/ocean-node/dist/index.js"],"cwd":"/home/paulo/workspace/OCEAN/ocean-node","execPath":"/home/paulo/.nvm/versions/node/v20.16.0/bin/node","gid":1000,"memoryUsage":{"arrayBuffers":578968,"external":5188011,"heapTotal":145915904,"heapUsed":113490792,"rss":223506432},"pid":906712,"uid":1000,"version":"v20.16.0"},"stack":"Error: write ECONNRESET\n    at afterWriteDispatched (node:internal/stream_base_commons:161:15)\n    at writeGeneric (node:internal/stream_base_commons:152:3)\n    at Socket._writeGeneric (node:net:954:11)\n    at Socket._write (node:net:966:8)\n    at writeOrBuffer (node:internal/streams/writable:570:12)\n    at _write (node:internal/streams/writable:499:10)\n    at Writable.write (node:internal/streams/writable:508:10)\n    at file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/stream-to-it/dist/src/sink.js:77:31\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.sink (file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/@libp2p/tcp/dist/src/socket-to-conn.js:72:17)","trace":[{"column":15,"file":"node:internal/stream_base_commons","function":"afterWriteDispatched","line":161,"method":null,"native":false},{"column":3,"file":"node:internal/stream_base_commons","function":"writeGeneric","line":152,"method":null,"native":false},{"column":11,"file":"node:net","function":"Socket._writeGeneric","line":954,"method":"_writeGeneric","native":false},{"column":8,"file":"node:net","function":"Socket._write","line":966,"method":"_write","native":false},{"column":12,"file":"node:internal/streams/writable","function":"writeOrBuffer","line":570,"method":null,"native":false},{"column":10,"file":"node:internal/streams/writable","function":"_write","line":499,"method":null,"native":false},{"column":10,"file":"node:internal/streams/writable","function":"Writable.write","line":508,"method":"write","native":false},{"column":31,"file":"file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/stream-to-it/dist/src/sink.js","function":null,"line":77,"method":null,"native":false},{"column":5,"file":"node:internal/process/task_queues","function":"process.processTicksAndRejections","line":95,"method":"processTicksAndRejections","native":false},{"column":17,"file":"file:///home/paulo/workspace/OCEAN/ocean-node/node_modules/@libp2p/tcp/dist/src/socket-to-conn.js","function":"async Object.sink","line":72,"method":"sink","native":false}]}
`
