### PR TITLE
make sure we always start indexing on ganache, even if no block info available (from block 0)…

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -141,3 +141,7 @@ export function asyncCallWithTimeout(
     }
   })
 }
+
+export function isDefined(something: any): boolean {
+  return something !== undefined && something !== null
+}


### PR DESCRIPTION
…, from block zero

Fixes #493 

Changes proposed in this PR:

- even if we can't get block info, we still start from block 0 (local network only) 
- helper utils fn to check for undefined/null same time