### PR TITLE
add unsafe URL & make config required for Storage classes

### DIFF
--- a/env.md
+++ b/env.md
@@ -28,6 +28,7 @@ Environmental variables are also tracked in `ENVIRONMENT_VARIABLES` within `src/
 - `LOG_CONSOLE`: Write logs to the console. Default is `false`, but becomes `true` if neither `LOG_FILES` or `LOG_DB` are set.
 - `LOG_FILES`: Write logs to files. Default is `false`
 - `LOG_DB`: Write logs to noSQL database. Default is `false`
+- `UNSAFE_URLS`: Array or regular expression URLs to be excluded from access.Example: ["^.*(169.254.169.254).*","^.*(127.0.0.1).*"]
 
 ## HTTP
 

--- a/src/@types/OceanNode.ts
+++ b/src/@types/OceanNode.ts
@@ -73,6 +73,7 @@ export interface OceanNodeConfig {
   codeHash?: string
   rateLimit?: number
   denyList?: DenyList
+  unsafeURLs?: string[]
 }
 
 export interface P2PStatusResponse {

--- a/src/components/core/handler/downloadHandler.ts
+++ b/src/components/core/handler/downloadHandler.ts
@@ -65,10 +65,10 @@ export async function handleDownloadUrlCommand(
 ): Promise<P2PCommandResponse> {
   const encryptFile = !!task.aes_encrypted_key
   CORE_LOGGER.logMessage('DownloadCommand requires file encryption? ' + encryptFile, true)
-
+  const config = await getConfiguration()
   try {
     // Determine the type of storage and get a readable stream
-    const storage = Storage.getStorageClass(task.fileObject)
+    const storage = Storage.getStorageClass(task.fileObject, config)
     if (
       storage instanceof ArweaveStorage &&
       !existsEnvironmentVariable(ENVIRONMENT_VARIABLES.ARWEAVE_GATEWAY)
@@ -125,7 +125,6 @@ export async function handleDownloadUrlCommand(
       // we parse the string into the object again
       const encryptedObject = ethCrypto.cipher.parse(task.aes_encrypted_key)
       // get the key from configuration
-      const config = await getConfiguration()
       const nodePrivateKey = Buffer.from(config.keys.privateKey).toString('hex')
       const decrypted = await ethCrypto.decryptWithPrivateKey(
         nodePrivateKey,

--- a/src/components/core/handler/encryptHandler.ts
+++ b/src/components/core/handler/encryptHandler.ts
@@ -119,7 +119,7 @@ export class EncryptFileHandler extends Handler {
       }
       let encryptedContent: Buffer
       if (task.files) {
-        const storage = Storage.getStorageClass(task.files)
+        const storage = Storage.getStorageClass(task.files, config)
         encryptedContent = await storage.encryptContent(task.encryptionType)
       } else if (task.rawData !== null) {
         encryptedContent = await encrypt(task.rawData, task.encryptionType)

--- a/src/components/core/handler/fileInfoHandler.ts
+++ b/src/components/core/handler/fileInfoHandler.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../@types/fileObject.js'
 import { FileInfoCommand } from '../../../@types/commands.js'
 import { CORE_LOGGER } from '../../../utils/logging/common.js'
-import { ArweaveStorage, IpfsStorage, UrlStorage } from '../../storage/index.js'
+import { Storage } from '../../storage/index.js'
 import { Handler } from './handler.js'
 import { validateDDOIdentifier } from './ddoHandler.js'
 import { fetchFileMetadata } from '../../../utils/asset.js'
@@ -18,7 +18,7 @@ import {
   validateCommandParameters
 } from '../../httpRoutes/validateCommands.js'
 import { getFile } from '../../../utils/file.js'
-
+import { getConfiguration } from '../../../utils/index.js'
 async function formatMetadata(file: ArweaveFileObject | IpfsFileObject | UrlFileObject) {
   const url =
     file.type === 'url'
@@ -79,14 +79,7 @@ export class FileInfoHandler extends Handler {
       let fileInfo = []
 
       if (task.file && task.type) {
-        const storage =
-          task.type === 'url'
-            ? new UrlStorage(task.file as UrlFileObject)
-            : task.type === 'arweave'
-            ? new ArweaveStorage(task.file as ArweaveFileObject)
-            : task.type === 'ipfs'
-            ? new IpfsStorage(task.file as IpfsFileObject)
-            : null
+        const storage = Storage.getStorageClass(task.file, await getConfiguration())
 
         fileInfo = await storage.getFileInfo({
           type: task.type,

--- a/src/test/unit/storage.test.ts
+++ b/src/test/unit/storage.test.ts
@@ -41,8 +41,10 @@ describe('URL Storage tests', () => {
   }
   let storage: Storage
   let error: Error
-  before(() => {
-    storage = Storage.getStorageClass(file)
+  let config: any
+  before(async () => {
+    config = await getConfiguration()
+    storage = Storage.getStorageClass(file, config)
   })
 
   it('Storage instance', () => {
@@ -81,7 +83,7 @@ describe('URL Storage tests', () => {
       ]
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -99,7 +101,7 @@ describe('URL Storage tests', () => {
       ]
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -120,7 +122,7 @@ describe('URL Storage tests', () => {
       ]
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -140,7 +142,7 @@ describe('URL Storage tests', () => {
       ]
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -160,7 +162,7 @@ describe('URL Storage tests', () => {
         }
       ]
     }
-    storage = Storage.getStorageClass(file)
+    storage = Storage.getStorageClass(file, config)
     expect(storage.getDownloadUrl()).to.eql('http://someUrl.com/file.json')
   })
 
@@ -170,9 +172,54 @@ describe('URL Storage tests', () => {
       url: 'https://stock-api.oceanprotocol.com/stock/stock.json',
       method: 'get'
     }
-    const storage = Storage.getStorageClass(file)
+    const storage = Storage.getStorageClass(file, config)
     const stream = await storage.getReadableStream()
     expect(stream).not.to.eql(null)
+  })
+})
+
+describe('Unsafe URL tests', () => {
+  let previousConfiguration: OverrideEnvConfig[]
+  let file: any
+  let error: Error
+  let config: any
+  before(async () => {
+    previousConfiguration = await setupEnvironment(
+      null,
+      buildEnvOverrideConfig(
+        [ENVIRONMENT_VARIABLES.UNSAFE_URLS],
+        [JSON.stringify(['^.*(169.254.169.254).*', '^.*(127.0.0.1).*'])]
+      )
+    )
+    config = await getConfiguration(true)
+  })
+
+  it('Should reject unsafe URL', () => {
+    file = {
+      type: 'url',
+      url: 'http://169.254.169.254/asfd',
+      method: 'get'
+    }
+    try {
+      Storage.getStorageClass(file, config)
+    } catch (err) {
+      error = err
+    }
+    expect(error.message).to.eql(
+      'Error validationg the URL file: URL is marked as unsafe'
+    )
+  })
+  it('Should allow safe URL', () => {
+    file = {
+      type: 'url',
+      url: 'https://oceanprotocol.com',
+      method: 'get'
+    }
+    const storage = Storage.getStorageClass(file, config)
+    expect(storage.getDownloadUrl()).to.eql('https://oceanprotocol.com')
+  })
+  after(() => {
+    tearDownEnvironment(previousConfiguration)
   })
 })
 
@@ -183,26 +230,27 @@ describe('IPFS Storage tests', () => {
   }
   let error: Error
   let previousConfiguration: OverrideEnvConfig[]
-
-  before(() => {
+  let config: any
+  before(async () => {
     previousConfiguration = buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.IPFS_GATEWAY],
       ['https://ipfs.oceanprotocol.com']
     )
+    config = await getConfiguration()
   })
 
   it('Storage instance', () => {
-    expect(Storage.getStorageClass(file)).to.be.instanceOf(IpfsStorage)
+    expect(Storage.getStorageClass(file, config)).to.be.instanceOf(IpfsStorage)
   })
   it('IPFS validation passes', () => {
-    expect(Storage.getStorageClass(file).validate()).to.eql([true, ''])
+    expect(Storage.getStorageClass(file, config).validate()).to.eql([true, ''])
   })
   it('IPFS validation fails', () => {
     file = {
       type: 'ipfs'
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -222,26 +270,28 @@ describe('Arweave Storage tests', () => {
 
   let error: Error
   let previousConfiguration: OverrideEnvConfig[]
+  let config: any
 
-  before(() => {
+  before(async () => {
     previousConfiguration = buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.ARWEAVE_GATEWAY],
       ['https://snaznabndfe3.arweave.net/nnLNdp6nuTb8mJ-qOgbUEx-9SBtBXQc_jejYOWzYEkM']
     )
+    config = await getConfiguration()
   })
 
   it('Storage instance', () => {
-    expect(Storage.getStorageClass(file)).to.be.instanceOf(ArweaveStorage)
+    expect(Storage.getStorageClass(file, config)).to.be.instanceOf(ArweaveStorage)
   })
   it('Arweave validation passes', () => {
-    expect(Storage.getStorageClass(file).validate()).to.eql([true, ''])
+    expect(Storage.getStorageClass(file, config).validate()).to.eql([true, ''])
   })
   it('Arweave validation fails', () => {
     file = {
       type: 'arweave'
     }
     try {
-      Storage.getStorageClass(file)
+      Storage.getStorageClass(file, config)
     } catch (err) {
       error = err
     }
@@ -257,12 +307,16 @@ describe('Arweave Storage tests', () => {
 
 describe('URL Storage getFileInfo tests', () => {
   let storage: UrlStorage
-  before(() => {
-    storage = new UrlStorage({
-      type: 'url',
-      url: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt',
-      method: 'get'
-    })
+  before(async () => {
+    const config = await getConfiguration()
+    storage = new UrlStorage(
+      {
+        type: 'url',
+        url: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt',
+        method: 'get'
+      },
+      config
+    )
   })
 
   it('isEncrypted should return false for an encrypted file', () => {
@@ -302,15 +356,22 @@ describe('URL Storage getFileInfo tests', () => {
 
 describe('URL Storage with malformed URL', () => {
   let error: Error
+  let config: any
+  before(async () => {
+    config = await getConfiguration()
+  })
 
   it('should detect path regex', () => {
     try {
       // eslint-disable-next-line no-new
-      new UrlStorage({
-        type: 'url',
-        url: '../../myFolder/',
-        method: 'get'
-      })
+      new UrlStorage(
+        {
+          type: 'url',
+          url: '../../myFolder/',
+          method: 'get'
+        },
+        config
+      )
     } catch (err) {
       error = err
     }
@@ -324,11 +385,15 @@ describe('Arweave Storage getFileInfo tests', function () {
   // this.timeout(15000)
   let storage: ArweaveStorage
 
-  before(() => {
-    storage = new ArweaveStorage({
-      type: FileObjectType.ARWEAVE,
-      transactionId: 'gPPDyusRh2ZyFl-sQ2ODK6hAwCRBAOwp0OFKr0n23QE'
-    })
+  before(async () => {
+    const config = await getConfiguration()
+    storage = new ArweaveStorage(
+      {
+        type: FileObjectType.ARWEAVE,
+        transactionId: 'gPPDyusRh2ZyFl-sQ2ODK6hAwCRBAOwp0OFKr0n23QE'
+      },
+      config
+    )
   })
 
   it('Successfully retrieves file info for an Arweave transaction', async () => {
@@ -358,15 +423,21 @@ describe('Arweave Storage getFileInfo tests', function () {
 
 describe('Arweave Storage with malformed transaction ID', () => {
   let error: Error
-
+  let config: any
+  before(async () => {
+    config = await getConfiguration()
+  })
   it('should detect URL path format', () => {
     try {
       // eslint-disable-next-line no-new
-      new ArweaveStorage({
-        type: 'arweave',
-        transactionId:
-          'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt'
-      })
+      new ArweaveStorage(
+        {
+          type: 'arweave',
+          transactionId:
+            'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt'
+        },
+        config
+      )
     } catch (err) {
       error = err
     }
@@ -378,10 +449,13 @@ describe('Arweave Storage with malformed transaction ID', () => {
   it('should detect path regex', () => {
     try {
       // eslint-disable-next-line no-new
-      new ArweaveStorage({
-        type: 'arweave',
-        transactionId: '../../myFolder/'
-      })
+      new ArweaveStorage(
+        {
+          type: 'arweave',
+          transactionId: '../../myFolder/'
+        },
+        config
+      )
     } catch (err) {
       error = err
     }
@@ -393,14 +467,20 @@ describe('Arweave Storage with malformed transaction ID', () => {
 
 describe('Arweave Storage with malformed transaction ID', () => {
   let error: Error
-
+  let config: any
+  before(async () => {
+    config = await getConfiguration()
+  })
   it('should detect URL path format', () => {
     try {
       // eslint-disable-next-line no-new
-      new IpfsStorage({
-        type: 'ipfs',
-        hash: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt'
-      })
+      new IpfsStorage(
+        {
+          type: 'ipfs',
+          hash: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt'
+        },
+        config
+      )
     } catch (err) {
       error = err
     }
@@ -412,10 +492,13 @@ describe('Arweave Storage with malformed transaction ID', () => {
   it('should detect path regex', () => {
     try {
       // eslint-disable-next-line no-new
-      new IpfsStorage({
-        type: 'ipfs',
-        hash: '../../myFolder/'
-      })
+      new IpfsStorage(
+        {
+          type: 'ipfs',
+          hash: '../../myFolder/'
+        },
+        config
+      )
     } catch (err) {
       error = err
     }
@@ -428,18 +511,22 @@ describe('Arweave Storage with malformed transaction ID', () => {
 describe('IPFS Storage getFileInfo tests', function () {
   let storage: IpfsStorage
   let previousConfiguration: OverrideEnvConfig[]
-
+  let config: any
   before(async () => {
     previousConfiguration = await buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.IPFS_GATEWAY],
       ['https://ipfs.oceanprotocol.com']
     )
     await setupEnvironment(undefined, previousConfiguration) // Apply the environment override
+    config = await getConfiguration()
 
-    storage = new IpfsStorage({
-      type: FileObjectType.IPFS,
-      hash: 'QmRhsp7eghZtW4PktPC2wAHdKoy2LiF1n6UXMKmAhqQJUA'
-    })
+    storage = new IpfsStorage(
+      {
+        type: FileObjectType.IPFS,
+        hash: 'QmRhsp7eghZtW4PktPC2wAHdKoy2LiF1n6UXMKmAhqQJUA'
+      },
+      config
+    )
   })
 
   it('Successfully retrieves file info for an IPFS hash', function () {
@@ -480,13 +567,17 @@ describe('IPFS Storage getFileInfo tests', function () {
 
 describe('URL Storage encryption tests', () => {
   let storage: UrlStorage
-
-  before(() => {
-    storage = new UrlStorage({
-      type: 'url',
-      url: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt',
-      method: 'get'
-    })
+  let config: any
+  before(async () => {
+    config = await getConfiguration()
+    storage = new UrlStorage(
+      {
+        type: 'url',
+        url: 'https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt',
+        method: 'get'
+      },
+      config
+    )
   })
 
   it('isEncrypted should return false for an encrypted file', () => {
@@ -502,7 +593,7 @@ describe('URL Storage encryption tests', () => {
   })
 
   it('encrypt method should correctly encrypt data', async () => {
-    const { keys } = await getConfiguration()
+    const { keys } = config
     nodeId = keys.peerId.toString()
     // Perform encryption
     const encryptResponse = await storage.encrypt(EncryptMethod.AES)
@@ -539,13 +630,16 @@ describe('URL Storage encryption tests', function () {
       ['https://ipfs.oceanprotocol.com']
     )
     await setupEnvironment(undefined, previousConfiguration) // Apply the environment override
-
-    storage = new IpfsStorage({
-      type: 'ipfs',
-      hash: 'QmQVPuoXMbVEk7HQBth5pGPPMcgvuq4VSgu2XQmzU5M2Pv',
-      encryptedBy: nodeId,
-      encryptMethod: EncryptMethod.AES
-    })
+    const config = await getConfiguration()
+    storage = new IpfsStorage(
+      {
+        type: 'ipfs',
+        hash: 'QmQVPuoXMbVEk7HQBth5pGPPMcgvuq4VSgu2XQmzU5M2Pv',
+        encryptedBy: nodeId,
+        encryptMethod: EncryptMethod.AES
+      },
+      config
+    )
   })
 
   it('isEncrypted should return true for an encrypted file', () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,7 +9,7 @@ import {
   EnvVariable,
   hexStringToByteArray
 } from '../utils/index.js'
-import { defaultBootstrapAddresses } from '../utils/constants.js'
+import { defaultBootstrapAddresses, knownUnsafeURLs } from '../utils/constants.js'
 
 import { LOG_LEVELS_STR, GENERIC_EMOJIS, getLoggerLevelEmoji } from './logging/Logger.js'
 import { RPCS } from '../@types/blockchain'
@@ -509,7 +509,12 @@ async function getEnvConfig(isStartup?: boolean): Promise<OceanNodeConfig> {
     assetPurgatoryUrl: getEnvValue(process.env.ASSET_PURGATORY_URL, ''),
     allowedAdmins: getAllowedAdmins(isStartup),
     rateLimit: getRateLimit(isStartup),
-    denyList: getDenyList(isStartup)
+    denyList: getDenyList(isStartup),
+    unsafeURLs: readListFromEnvVariable(
+      ENVIRONMENT_VARIABLES.UNSAFE_URLS,
+      isStartup,
+      knownUnsafeURLs
+    )
   }
 
   if (!previousConfiguration) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -295,6 +295,11 @@ export const ENVIRONMENT_VARIABLES: Record<any, EnvVariable> = {
     name: 'LOG_DB',
     value: process.env.LOG_DB,
     required: false
+  },
+  UNSAFE_URLS: {
+    name: 'UNSAFE_URLS',
+    value: process.env.UNSAFE_URLS,
+    required: false
   }
 }
 
@@ -333,3 +338,5 @@ export const defaultBootstrapAddresses = [
   '/dns6/node4.oceanprotocol.com/tcp/9002/p2p/16Uiu2HAmSTVTArioKm2wVcyeASHYEsnx2ZNq467Z4GMDU4ErEPom',
   '/dns6/node4.oceanprotocol.com/tcp/9003/ws/p2p/16Uiu2HAmSTVTArioKm2wVcyeASHYEsnx2ZNq467Z4GMDU4ErEPom'
 ]
+
+export const knownUnsafeURLs: string[] = []

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -339,4 +339,18 @@ export const defaultBootstrapAddresses = [
   '/dns6/node4.oceanprotocol.com/tcp/9003/ws/p2p/16Uiu2HAmSTVTArioKm2wVcyeASHYEsnx2ZNq467Z4GMDU4ErEPom'
 ]
 
-export const knownUnsafeURLs: string[] = []
+export const knownUnsafeURLs: string[] = [
+  // AWS and GCP
+  '^.*(169.254.169.254).*',
+  // GCP
+  '^.*(metadata.google.internal).*',
+  '^.*(http://metadata).*',
+  // Azure
+  '^.*(http://169.254.169.254).*',
+  // Oracle Cloud
+  '^.*(http://192.0.0.192).*',
+  // Alibaba Cloud
+  '^.*(http://100.100.100.200).*',
+  // k8s ETCD
+  '^.*(127.0.0.1).*'
+]


### PR DESCRIPTION
Closes #106

Changes proposed in this PR:

- add env UNSAFE_URLS, which is an array of regular expressions.  If asset URL is a match, access is denied
- add config to Storage constructor



Motivation:
  Image a hacker publishing an asset with an URL like "http://169.254.169.254/latest/meta-data/".  Then by "downloading" his asset, he will get access to your cloud provider provided metadata, which is a huge security risk