### PR TITLE
add getP2pNetworkStats route

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -69,6 +69,7 @@ Environmental variables are also tracked in `ENVIRONMENT_VARIABLES` within `src/
 - `P2P_AUTODIALCONCURRENCY`: When dialling peers from the peer book to keep the number of open connections, add dials for this many peers to the dial queue at once. Default: 5
 - `P2P_MAXPEERADDRSTODIAL`: Maximum number of addresses allowed for a given peer before giving up. Default: 5
 - `P2P_AUTODIALINTERVAL`: Auto dial interval (miliseconds). Amount of time between close and open of new peer connection. Default: 5000
+- `P2P_ENABLE_NETWORK_STATS`: Enables 'getP2pNetworkStats' http endpoint. Since this contains private informations (like your ip addresses), this is disabled by default
 
 ## Additional Nodes (Test Environments)
 

--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -438,8 +438,10 @@ export class OceanP2P extends EventEmitter {
 
   async getNetworkingStats() {
     const ret: any = {}
-    ret.addrs = await this._libp2p.components.transportManager.getAddrs()
+    ret.binds = await this._libp2p.components.addressManager.getListenAddrs()
+    ret.listen = await this._libp2p.components.transportManager.getAddrs()
     ret.observing = await this._libp2p.components.addressManager.getObservedAddrs()
+    ret.announce = await this._libp2p.components.addressManager.getAnnounceAddrs()
     ret.connections = await this._libp2p.getConnections()
     return ret
   }

--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -436,6 +436,14 @@ export class OceanP2P extends EventEmitter {
     // }
   }
 
+  async getNetworkingStats() {
+    const ret: any = {}
+    ret.addrs = await this._libp2p.components.transportManager.getAddrs()
+    ret.observing = await this._libp2p.components.addressManager.getObservedAddrs()
+    ret.connections = await this._libp2p.getConnections()
+    return ret
+  }
+
   async getRunningOceanPeers() {
     return await this.getOceanPeers(true, false)
   }

--- a/src/components/httpRoutes/getOceanPeers.ts
+++ b/src/components/httpRoutes/getOceanPeers.ts
@@ -6,6 +6,18 @@ import { hasP2PInterface, sendMissingP2PResponse } from './index.js'
 export const getOceanPeersRoute = express.Router()
 
 getOceanPeersRoute.get(
+  '/getP2pNetworkStats',
+  async (req: Request, res: Response): Promise<void> => {
+    if (hasP2PInterface) {
+      const stats = await req.oceanNode.getP2PNode().getNetworkingStats()
+      P2P_LOGGER.log(getDefaultLevel(), `getP2pNetworkStats: ${stats}`, true)
+      res.json(stats)
+    } else {
+      sendMissingP2PResponse(res)
+    }
+  }
+)
+getOceanPeersRoute.get(
   '/getOceanPeers',
   async (req: Request, res: Response): Promise<void> => {
     if (hasP2PInterface) {

--- a/src/components/httpRoutes/getOceanPeers.ts
+++ b/src/components/httpRoutes/getOceanPeers.ts
@@ -2,18 +2,19 @@ import express, { Request, Response } from 'express'
 import { getDefaultLevel } from '../../utils/logging/Logger.js'
 import { P2P_LOGGER } from '../../utils/logging/common.js'
 import { hasP2PInterface, sendMissingP2PResponse } from './index.js'
-
+import { getBoolEnvValue } from '../../utils/config.js'
 export const getOceanPeersRoute = express.Router()
 
 getOceanPeersRoute.get(
   '/getP2pNetworkStats',
   async (req: Request, res: Response): Promise<void> => {
-    if (hasP2PInterface) {
+    // only return values if env P2P_ENABLE_NETWORK_STATS is explicitly allowed
+    if (hasP2PInterface && getBoolEnvValue('P2P_ENABLE_NETWORK_STATS', false)) {
       const stats = await req.oceanNode.getP2PNode().getNetworkingStats()
       P2P_LOGGER.log(getDefaultLevel(), `getP2pNetworkStats: ${stats}`, true)
       res.json(stats)
     } else {
-      sendMissingP2PResponse(res)
+      res.status(400).send('Not enabled or unavailable')
     }
   }
 )

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,7 +57,7 @@ function getIntEnvValue(env: any, defaultValue: number) {
   return isNaN(num) ? defaultValue : num
 }
 
-function getBoolEnvValue(envName: string, defaultValue: boolean): boolean {
+export function getBoolEnvValue(envName: string, defaultValue: boolean): boolean {
   if (!(envName in process.env)) {
     return defaultValue
   }


### PR DESCRIPTION
Changes proposed in this PR:

- add a new http route called "getP2pNetworkStats" that exposes stats about the p2p network
- used for debuging, as it gives extended information about networking
- you MUST set env P2P_ENABLE_NETWORK_STATS=TRUE to enable, as it contains private data

Example output:
```json
{
  "binds": [
    "/ip4/0.0.0.0/tcp/9000",
    "/ip4/0.0.0.0/tcp/9001/ws",
    "/ip6/::1/tcp/9002",
    "/ip6/::1/tcp/9003/ws"
  ],
  "listen": [
    "/ip4/127.0.0.1/tcp/9001/ws",
    "/ip4/10.255.255.254/tcp/9001/ws",
    "/ip4/172.23.54.159/tcp/9001/ws",
    "/ip4/127.0.0.1/tcp/9000",
    "/ip4/10.255.255.254/tcp/9000",
    "/ip4/172.23.54.159/tcp/9000",
    "/ip6/::1/tcp/9002"
  ],
  "observing": [
    "/ip4/188.27.96.232/tcp/49714",
    "/ip4/188.27.96.232/tcp/49794",
    "/ip4/188.27.96.232/tcp/49776",
    "/ip4/188.27.96.232/tcp/49766",
    "/ip4/188.27.96.232/tcp/49800",
    "/ip4/188.27.96.232/tcp/49742",
    "/ip4/188.27.96.232/tcp/49710",
    "/ip4/188.27.96.232/tcp/49718",
    "/ip4/188.27.96.232/tcp/49724",
    "/ip4/188.27.96.232/tcp/49752"
  ],
  "announce": [],
  "connections": [
    {
      "id": "daccn21723732444140",
      "remoteAddr": "/dns4/node2.oceanprotocol.com/tcp/9000/p2p/16Uiu2HAmHwzeVw7RpGopjZe6qNBJbzDDBdqtrSk7Gcx1emYsfgL4",
      "remotePeer": "16Uiu2HAmHwzeVw7RpGopjZe6qNBJbzDDBdqtrSk7Gcx1emYsfgL4",
      "direction": "outbound",
      "timeline": {
        "open": 1723732444022,
        "upgraded": 1723732444140
      },
      "multiplexer": "/yamux/1.0.0",
      "encryption": "/noise",
      "status": "open",
      "transient": false,
      "tags": []
    },
    {
      "id": "28zl101723732444171",
      "remoteAddr": "/dns4/node4.oceanprotocol.com/tcp/9000/p2p/16Uiu2HAmSTVTArioKm2wVcyeASHYEsnx2ZNq467Z4GMDU4ErEPom",
      "remotePeer": "16Uiu2HAmSTVTArioKm2wVcyeASHYEsnx2ZNq467Z4GMDU4ErEPom",
      "direction": "outbound",
      "timeline": {
        "open": 1723732444034,
        "upgraded": 1723732444171
      },
      "multiplexer": "/yamux/1.0.0",
      "encryption": "/noise",
      "status": "open",
      "transient": false,
      "tags": []
    }
  ]
}
```