### PR TITLE
P2P: fix external address announce

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -311,12 +311,27 @@ export class OceanP2P extends EventEmitter {
         P2P_LOGGER.info('Enabling P2P Transports: websockets, tcp')
         transports = [webSockets(), tcp()]
       }
-      let options = {
-        addresses: {
+
+      let addresses = {}
+      if (
+        config.p2pConfig.announceAddresses &&
+        config.p2pConfig.announceAddresses.length > 0
+      ) {
+        addresses = {
+          listen: bindInterfaces,
+          announceFilter: (multiaddrs: any[]) =>
+            multiaddrs.filter((m) => this.shouldAnnounce(m)),
+          announce: config.p2pConfig.announceAddresses
+        }
+      } else {
+        addresses = {
           listen: bindInterfaces,
           announceFilter: (multiaddrs: any[]) =>
             multiaddrs.filter((m) => this.shouldAnnounce(m))
-        },
+        }
+      }
+      let options = {
+        addresses,
         peerId: config.keys.peerId,
         transports,
         streamMuxers: [yamux()],


### PR DESCRIPTION
Even if we had P2P_ANNOUNCE_ADDRESSES in config, we were not announcing any users specified addresses

Changes proposed in this PR:

-  fix
- 
- 