### PR TITLE
always enable circuit relay

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -59,8 +59,7 @@ Environmental variables are also tracked in `ENVIRONMENT_VARIABLES` within `src/
 - `P2P_ENABLE_UPNP`: Enable UPNP gateway discovery. Default: `True`
 - `P2P_ENABLE_AUTONAT`: Enable AutoNAT discovery. Default: `True`
 - `P2P_ENABLE_CIRCUIT_RELAY_SERVER`: Enable Circuit Relay Server. It will help the network but increase your bandwidth usage. Should be disabled for edge nodes. Default: `True`
-- `P2P_ENABLE_CIRCUIT_RELAY_CLIENT`: Enable connections through relay servers. Default: `True`
-- `P2P_CIRCUIT_RELAYS`: Numbers of relay servers. Default: `1`
+- `P2P_CIRCUIT_RELAYS`: Numbers of relay servers. Default: `0`
 - `P2P_BOOTSTRAP_NODES` : List of bootstrap nodes. Defults to OPF nodes. Example: ["/dns4/node3.oceanprotocol.com/tcp/9000/p2p/"]
 - `P2P_FILTER_ANNOUNCED_ADDRESSES`: CIDR filters to filter announced addresses. Default: ["172.15.0.0/24"] (docker ip range). Example: ["192.168.0.1/27"]
 - `P2P_MIN_CONNECTIONS`: The minimum number of connections below which libp2p will start to dial peers from the peer book. Setting this to 0 disables this behaviour. Default: 1

--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -298,19 +298,14 @@ export class OceanP2P extends EventEmitter {
         )
       }
       let transports = []
-      if (config.p2pConfig.enableCircuitRelayClient) {
-        P2P_LOGGER.info('Enabling P2P Transports: websockets, tcp, circuitRelay')
-        transports = [
-          webSockets(),
-          tcp(),
-          circuitRelayTransport({
-            discoverRelays: config.p2pConfig.circuitRelays
-          })
-        ]
-      } else {
-        P2P_LOGGER.info('Enabling P2P Transports: websockets, tcp')
-        transports = [webSockets(), tcp()]
-      }
+      P2P_LOGGER.info('Enabling P2P Transports: websockets, tcp, circuitRelay')
+      transports = [
+        webSockets(),
+        tcp(),
+        circuitRelayTransport({
+          discoverRelays: config.p2pConfig.circuitRelays
+        })
+      ]
 
       let addresses = {}
       if (

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -525,7 +525,7 @@ async function getEnvConfig(isStartup?: boolean): Promise<OceanNodeConfig> {
       autoNat: getBoolEnvValue('P2P_ENABLE_AUTONAT', true),
       enableCircuitRelayServer: getBoolEnvValue('P2P_ENABLE_CIRCUIT_RELAY_SERVER', false),
       enableCircuitRelayClient: getBoolEnvValue('P2P_ENABLE_CIRCUIT_RELAY_CLIENT', false),
-      circuitRelays: getIntEnvValue(process.env.P2P_CIRCUIT_RELAYS, 1),
+      circuitRelays: getIntEnvValue(process.env.P2P_CIRCUIT_RELAYS, 0),
       announcePrivateIp: getBoolEnvValue('P2P_ANNOUNCE_PRIVATE', false),
       filterAnnouncedAddresses: readListFromEnvVariable(
         ENVIRONMENT_VARIABLES.P2P_FILTER_ANNOUNCED_ADDRESSES,


### PR DESCRIPTION
Circuit relay (p2p-circuit) is another method of transport (just like tcp or ws).
We should always be able to dial such peers.

Also, changed P2P_CIRCUIT_RELAYS default value to 0  (ie: do not create p2p circuits by default)