### PR TITLE
use multiaddrs for sendTo

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -48,7 +48,7 @@ import {
 import { INDEXER_DDO_EVENT_EMITTER } from '../Indexer/index.js'
 import { P2P_LOGGER } from '../../utils/logging/common.js'
 import { CoreHandlersRegistry } from '../core/handler/coreHandlersRegistry'
-import { multiaddr } from '@multiformats/multiaddr'
+import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
 // import { getIPv4, getIPv6 } from '../../utils/ip.js'
 
 const DEFAULT_OPTIONS = {
@@ -545,6 +545,70 @@ export class OceanP2P extends EventEmitter {
     }
   }
 
+  async getPeerMultiaddrs(
+    peerName: string,
+    searchPeerStore: boolean = true,
+    searchDHT: boolean = true
+  ): Promise<Multiaddr[]> {
+    const multiaddrs: Multiaddr[] = []
+    if (searchPeerStore) {
+      // search peerStore
+      try {
+        if (process.env.DEBUG) console.log('Search peer store')
+        const peerData = await this._libp2p.peerStore.get(peerName, {
+          signal: AbortSignal.timeout(3000)
+        })
+        if (peerData) {
+          for (const x of peerData.addresses) {
+            multiaddrs.push(x.multiaddr)
+          }
+        }
+      } catch (e) {
+        // console.log(e)
+      }
+    }
+    if (searchDHT) {
+      try {
+        const peerData = await this._libp2p.peerRouting.findPeer(peerName, {
+          signal: AbortSignal.timeout(3000),
+          useCache: false
+        })
+        if (peerData) {
+          for (const index in peerData.multiaddrs) {
+            multiaddrs.push(peerData.multiaddrs[index])
+          }
+        }
+      } catch (e) {
+        // console.log(e)
+      }
+    }
+
+    // now we should have peer multiaddrs
+    // but there is a catch
+    // when dialing multiaddrs, either all of them have peerId, or none..
+    // so decide which one to use
+    let finalmultiaddrs: Multiaddr[] = []
+    const finalmultiaddrsWithAddress: Multiaddr[] = []
+    const finalmultiaddrsWithoutAddress: Multiaddr[] = []
+    for (const x of multiaddrs) {
+      if (x.toString().includes(peerName)) finalmultiaddrsWithAddress.push(x)
+      else {
+        let sd = x.toString()
+        if (x.toString().includes('p2p-circuit')) {
+          // because a p2p-circuit should always include peerId, if it's missing we will add it
+          sd = sd + '/p2p/' + peerName
+          finalmultiaddrsWithAddress.push(multiaddr(sd))
+        } else {
+          finalmultiaddrsWithoutAddress.push(multiaddr(sd))
+        }
+      }
+    }
+    if (finalmultiaddrsWithAddress.length > finalmultiaddrsWithoutAddress.length)
+      finalmultiaddrs = finalmultiaddrsWithAddress
+    else finalmultiaddrs = finalmultiaddrsWithoutAddress
+    return finalmultiaddrs
+  }
+
   async sendTo(
     peerName: string,
     message: string,
@@ -559,7 +623,6 @@ export class OceanP2P extends EventEmitter {
     let peerId: any
     try {
       peerId = peerIdFromString(peerName)
-      await this._libp2p.peerStore.get(peerId)
     } catch (e) {
       P2P_LOGGER.logMessageWithEmoji(
         'Invalid peer (for id): ' + peerId,
@@ -571,11 +634,22 @@ export class OceanP2P extends EventEmitter {
       response.status.error = 'Invalid peer'
       return response
     }
+    const multiaddrs: Multiaddr[] = await this.getPeerMultiaddrs(peerName)
+    if (multiaddrs.length < 1) {
+      response.status.httpStatus = 404
+      response.status.error = `Cannot find any address to dial for peer: ${peerId}`
+      P2P_LOGGER.error(response.status.error)
+      return response
+    }
 
     let stream
     // dial/connect to the target node
     try {
-      stream = await this._libp2p.dialProtocol(peerId, this._protocol)
+      stream = await this._libp2p.dialProtocol(multiaddrs, this._protocol, {
+        signal: AbortSignal.timeout(3000),
+        priority: 100,
+        runOnTransientConnection: true
+      })
     } catch (e) {
       response.status.httpStatus = 404
       response.status.error = 'Cannot connect to peer'


### PR DESCRIPTION
For sendTo, we are getting peerDetails from peerStore.

But a node cannot be connected to all nodes in the network (we might have millions). This way, there is > 90% chances that our dial will fail.

So, proper way to dial is:
 - try to fetch peer multiaddrs from peerStore
 - try to fetch peer multiaddrs from DHT
 - use multiaddrs when dialing (instead of peerId)