### PR TITLE
fix default filtered p2p ip list (non routable ips that should not be announced)

### DIFF
--- a/src/test/unit/oceanP2P.test.ts
+++ b/src/test/unit/oceanP2P.test.ts
@@ -56,7 +56,7 @@ describe('OceanP2P Test', () => {
     config2.p2pConfig.bootstrapNodes = []
     // enable private IP
     config2.p2pConfig.announcePrivateIp = true
-    config1.p2pConfig.filterAnnouncedAddresses = ['172.15.0.0/24'] // allow nodes to see each other locally for tests
+    config2.p2pConfig.filterAnnouncedAddresses = ['172.15.0.0/24'] // allow nodes to see each other locally for tests
     node2 = new OceanP2P(config2, null)
     await node2.start()
     assert(node2, 'Failed to create P2P Node instance')

--- a/src/test/unit/oceanP2P.test.ts
+++ b/src/test/unit/oceanP2P.test.ts
@@ -42,6 +42,7 @@ describe('OceanP2P Test', () => {
     config1.p2pConfig.bootstrapNodes = []
     // enable private IP
     config1.p2pConfig.announcePrivateIp = true
+    config1.p2pConfig.filterAnnouncedAddresses = ['172.15.0.0/24']
     node1 = new OceanP2P(config1, null)
     await node1.start()
     assert(node1, 'Failed to create P2P Node instance')
@@ -55,6 +56,7 @@ describe('OceanP2P Test', () => {
     config2.p2pConfig.bootstrapNodes = []
     // enable private IP
     config2.p2pConfig.announcePrivateIp = true
+    config1.p2pConfig.filterAnnouncedAddresses = ['172.15.0.0/24'] // allow nodes to see each other locally for tests
     node2 = new OceanP2P(config2, null)
     await node2.start()
     assert(node2, 'Failed to create P2P Node instance')

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -536,7 +536,20 @@ async function getEnvConfig(isStartup?: boolean): Promise<OceanNodeConfig> {
       filterAnnouncedAddresses: readListFromEnvVariable(
         ENVIRONMENT_VARIABLES.P2P_FILTER_ANNOUNCED_ADDRESSES,
         isStartup,
-        ['172.15.0.0/24']
+        [
+          '127.0.0.0/8',
+          '10.0.0.0/8',
+          '172.16.0.0/12',
+          '192.168.0.0/16',
+          '100.64.0.0/10',
+          '169.254.0.0/16',
+          '192.0.0.0/24',
+          '192.0.2.0/24',
+          '198.51.100.0/24',
+          '203.0.113.0/24',
+          '224.0.0.0/4',
+          '240.0.0.0/4'
+        ] // list of all non-routable IP addresses, not availabe from public internet, private networks or specific reserved use
       ),
       minConnections: getIntEnvValue(process.env.P2P_MIN_CONNECTIONS, 1),
       maxConnections: getIntEnvValue(process.env.P2P_MAX_CONNECTIONS, 300),


### PR DESCRIPTION
Fixes #691 .

Changes proposed in this PR:

- set proper default non public ips on P2P_FILTER_ANNOUNCED_ADDRESSES
- 
- 