### PR TITLE
remove node 16 image references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,8 +230,6 @@ jobs:
           docker image rm node:20-alpine
           docker image rm node:18
           docker image rm node:18-alpine
-          docker image rm node:16
-          docker image rm node:16-alpine
           docker image rm debian:10
           docker image rm debian:11
           docker image rm ubuntu:22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,6 @@ jobs:
           docker image rm node:20-alpine
           docker image rm node:18
           docker image rm node:18-alpine
-          docker image rm node:16
-          docker image rm node:16-alpine
           docker image rm debian:10
           docker image rm debian:11
           docker image rm ubuntu:22.04


### PR DESCRIPTION
Fixes #

Changes proposed in this PR:

- remove node 16 from workflow, image not available anymore and tests fail
- 
- 