### PR TITLE
add possible missing 0x prefix on agreementId

### DIFF
--- a/src/components/core/compute/getStatus.ts
+++ b/src/components/core/compute/getStatus.ts
@@ -61,8 +61,7 @@ export class ComputeGetStatusHandler extends Handler {
           task.agreementId,
           jobId
         )
-        console.log('GOT JOBS')
-        console.log(jobs)
+
         if (jobs && jobs.length > 0) response.push(...jobs)
       }
       CORE_LOGGER.logMessage(

--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -182,6 +182,9 @@ export class SQLiteCompute implements ComputeDatabaseProvider {
       params.push(jobId)
     }
     if (agreementId) {
+      if (!agreementId.startsWith('0x')) {
+        agreementId = '0x' + agreementId
+      }
       selectSQL += ` AND agreementId = ?`
       params.push(agreementId)
     }


### PR DESCRIPTION
Fixes #776 

Changes proposed in this PR:
On the GetComputeStatus endpoint call from the CLI.. 
- The ocean SDK call to `computeStatus` removes the '0x' prefix on the `agreementId` field (not sure why it was done like that in the first place). But this causes a mismatch on the string, whenever that field is used on the query. 
- Here, we just double check and add it back if missing 
(we might need to update also the SDK if that is a bug there)