### PR TITLE
fix usage of getBoolEnvValue

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -549,7 +549,7 @@ async function getEnvConfig(isStartup?: boolean): Promise<OceanNodeConfig> {
       ),
       dhtMaxInboundStreams: getIntEnvValue(process.env.P2P_dhtMaxInboundStreams, 500),
       dhtMaxOutboundStreams: getIntEnvValue(process.env.P2P_dhtMaxOutboundStreams, 500),
-      enableDHTServer: getBoolEnvValue(process.env.P2P_ENABLE_DHT_SERVER, false),
+      enableDHTServer: getBoolEnvValue('P2P_ENABLE_DHT_SERVER', false),
       mDNSInterval: getIntEnvValue(process.env.P2P_mDNSInterval, 20e3), // 20 seconds
       connectionsMaxParallelDials: getIntEnvValue(
         process.env.P2P_connectionsMaxParallelDials,
@@ -617,7 +617,7 @@ async function getEnvConfig(isStartup?: boolean): Promise<OceanNodeConfig> {
       isStartup,
       knownUnsafeURLs
     ),
-    isBootstrap: getBoolEnvValue(process.env.IS_BOOTSTRAP, false)
+    isBootstrap: getBoolEnvValue('IS_BOOTSTRAP', false)
   }
 
   if (!previousConfiguration) {


### PR DESCRIPTION
Fixes #784

Changes proposed in this PR:

- Couple misuses of this `getBoolEnvValue` function (the param types are different from similar functions and usage was wrong at first glance) ... It was  not reading the env var properly
