### PR TITLE
add missing check for ddo DB on republish ddos

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -779,7 +779,7 @@ export class OceanP2P extends EventEmitter {
   // related: https://github.com/libp2p/go-libp2p-kad-dht/issues/323
   async republishStoredDDOS() {
     try {
-      if (!this.db) {
+      if (!this.db || !this.db.ddo) {
         P2P_LOGGER.logMessage(
           `republishStoredDDOS() attempt aborted because there is no database!`,
           true


### PR DESCRIPTION
Fixes #788

Changes proposed in this PR:

- Avoid error,check if DB exists but also if DDO db exists (we might have instance without the 2nd)
- This error is catched but could be avoided anyway
- 