### PR TITLE
recalculate code hash if needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,6 @@ declare global {
   }
 }
 
-export async function recalculateCodeHash(): Promise<string> {
-  const __filename = fileURLToPath(import.meta.url)
-  const __dirname = path.dirname(__filename)
-  const codeHash = await computeCodebaseHash(__dirname)
-  return codeHash
-}
 // we have 5 json examples
 // we should have some DDO class too
 function loadInitialDDOS(): any[] {
@@ -80,7 +74,9 @@ OCEAN_NODE_LOGGER.logMessageWithEmoji(
 )
 
 const config = await getConfiguration(true, isStartup)
-config.codeHash = await recalculateCodeHash()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+config.codeHash = await computeCodebaseHash(__dirname)
 
 OCEAN_NODE_LOGGER.info(`Codebase hash: ${config.codeHash}`)
 if (!config) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,12 @@ declare global {
   }
 }
 
+export async function recalculateCodeHash(): Promise<string> {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  const codeHash = await computeCodebaseHash(__dirname)
+  return codeHash
+}
 // we have 5 json examples
 // we should have some DDO class too
 function loadInitialDDOS(): any[] {
@@ -74,9 +80,7 @@ OCEAN_NODE_LOGGER.logMessageWithEmoji(
 )
 
 const config = await getConfiguration(true, isStartup)
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-config.codeHash = await computeCodebaseHash(__dirname)
+config.codeHash = await recalculateCodeHash()
 
 OCEAN_NODE_LOGGER.info(`Codebase hash: ${config.codeHash}`)
 if (!config) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils/address.js'
 import { CONFIG_LOGGER } from './logging/common.js'
 import { create256Hash } from './crypt.js'
+import { recalculateCodeHash } from '..'
 
 // usefull for lazy loading and avoid boilerplate on other places
 let previousConfiguration: OceanNodeConfig = null
@@ -475,6 +476,10 @@ export async function getConfiguration(
   if (!previousConfiguration || forceReload) {
     previousConfiguration = await getEnvConfig(isStartup)
   }
+  if (!previousConfiguration.codeHash) {
+    previousConfiguration.codeHash = await recalculateCodeHash()
+  }
+
   return previousConfiguration
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,6 +9,7 @@ import { C2DClusterType } from '../@types/C2D.js'
 import { createFromPrivKey } from '@libp2p/peer-id-factory'
 import { keys } from '@libp2p/crypto'
 import {
+  computeCodebaseHash,
   DEFAULT_RATE_LIMIT_PER_SECOND,
   ENVIRONMENT_VARIABLES,
   EnvVariable,
@@ -26,7 +27,8 @@ import {
 } from '../utils/address.js'
 import { CONFIG_LOGGER } from './logging/common.js'
 import { create256Hash } from './crypt.js'
-import { recalculateCodeHash } from '..'
+import { fileURLToPath } from 'url'
+import path from 'path'
 
 // usefull for lazy loading and avoid boilerplate on other places
 let previousConfiguration: OceanNodeConfig = null
@@ -477,7 +479,9 @@ export async function getConfiguration(
     previousConfiguration = await getEnvConfig(isStartup)
   }
   if (!previousConfiguration.codeHash) {
-    previousConfiguration.codeHash = await recalculateCodeHash()
+    const __filename = fileURLToPath(import.meta.url)
+    const __dirname = path.dirname(__filename.replace('utils/', ''))
+    previousConfiguration.codeHash = await computeCodebaseHash(__dirname)
   }
 
   return previousConfiguration


### PR DESCRIPTION
Fixes #772 

Changes proposed in this PR:

- code hash might need to be recalculated if config object does not contain key (e.g: after a config reload)
- this absence can cause the system tests to fail (property `codeHash` missing on the `status` command)
- 