### PR TITLE
C2D refactor (Free Compute)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "tsoa": "^5.1.1",
         "uint8arrays": "^4.0.6",
         "url-join": "^5.0.0",
+        "uuid": "^11.1.0",
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^4.7.1",
         "winston-transport": "^4.6.0"
@@ -10356,6 +10357,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "dev": true,
@@ -12007,6 +12017,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-domexception": {
@@ -17129,10 +17147,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "tsoa": "^5.1.1",
     "uint8arrays": "^4.0.6",
     "url-join": "^5.0.0",
+    "uuid": "^11.1.0",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1",
     "winston-transport": "^4.6.0"

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -97,6 +97,10 @@ export interface ComputeEnvByChain {
   [chainId: number]: ComputeEnvironment[]
 }
 
+export interface ComputeResourceRequest {
+  type: string
+  amount: number
+}
 export type ComputeResultType =
   | 'algorithmLog'
   | 'output'

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -34,6 +34,7 @@ export interface ComputeResource {
   total: number // total number of specific resource
   min: number // min number of resource needed for a job
   max: number // max number of resource for a job
+  inUse?: number // for display purposes
 }
 export interface ComputeResourceRequest {
   id: string
@@ -63,7 +64,8 @@ export interface ComputeEnvironmentFreeOptions {
 export interface ComputeEnvironmentBaseConfig {
   description?: string // v1
   storageExpiry?: number // amount of seconds for storage
-  maxJobDuration?: number // v1 max seconds for a paid job
+  minJobDuration?: number // min billable seconds for a paid job
+  maxJobDuration?: number // max duration in seconds for a paid job
   maxJobs?: number // maximum number of simultaneous paid jobs
   fees: ComputeEnvFeesStructure
   resources?: ComputeResource[]
@@ -73,7 +75,8 @@ export interface ComputeEnvironmentBaseConfig {
 
 export interface ComputeEnvironment extends ComputeEnvironmentBaseConfig {
   id: string // v1
-  currentJobs: number
+  runningJobs: number
+  runningfreeJobs?: number
   consumerAddress: string // v1
 }
 
@@ -89,7 +92,7 @@ export interface C2DDockerConfig {
   maxJobDuration?: number
   maxJobs?: number
   fees: ComputeEnvFeesStructure
-  maxDisk: number
+  resources?: ComputeResource[] // optional, owner can overwrite
   free?: ComputeEnvironmentFreeOptions
 }
 

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -20,18 +20,26 @@ export interface C2DClusterInfo {
   tempFolder?: string
 }
 
-// export type ComputeResourceType = 'cpu' | 'memory' | 'storage'
+export type ComputeResourceType = 'cpu' | 'ram' | 'disk' | any
 
 export interface ComputeResourcesPricingInfo {
-  id: string
-  price: number
+  id: ComputeResourceType
+  price: number // price per unit
 }
 
-export interface ComputeResources {
-  id: string
+export interface ComputeResource {
+  id: ComputeResourceType
   type?: string
   kind?: string
+  total: number // total number of specific resource
+  min: number // min number of resource needed for a job
+  max: number // max number of resource for a job
 }
+export interface ComputeResourceRequest {
+  id: string
+  amount: number
+}
+
 export interface ComputeEnvFees {
   feeToken: string
   prices: ComputeResourcesPricingInfo[]
@@ -47,33 +55,20 @@ export interface RunningPlatform {
 
 export interface ComputeEnvironmentFreeOptions {
   // only if a compute env exposes free jobs
-  maxCpu?: number // max cpu for a single job.
-  maxRam?: number // max allocatable RAM for a single job in bytes.
-  maxDisk?: number // max disk space in bytes allocatable for a single job
   storageExpiry?: number
   maxJobDuration?: number
-  maxJobs: number // maximum number of free jobs in the same time
+  maxJobs?: number // maximum number of simultaneous free jobs
+  resources?: ComputeResource[]
 }
 export interface ComputeEnvironmentBaseConfig {
-  // cpuNumber: number
-  // ramGB: number
-  // diskGB: number
   description?: string // v1
-  // maxJobs: number
-  storageExpiry: number // v1
-  maxJobDuration: number // v1 max seconds for a job
-  // chainId?: number
-  // feeToken: string
-  // priceMin: number
-  totalCpu?: number // total cpu available for jobs
-  totalRam?: number // total bytes of RAM
-  maxCpu?: number // max cpu for a single job.  Imagine a K8 cluster with two nodes, each node with 10 cpus.  Total=20, but at most you can allocate 10 cpu for a job
-  maxRam?: number // max allocatable RAM for a single job in bytes.
-  maxDisk?: number // max disk space in bytes allocatable for a single job
-  free?: ComputeEnvironmentFreeOptions
+  storageExpiry?: number // amount of seconds for storage
+  maxJobDuration?: number // v1 max seconds for a paid job
+  maxJobs?: number // maximum number of simultaneous paid jobs
   fees: ComputeEnvFeesStructure
-  resources?: ComputeResources[]
-  platform?: RunningPlatform[]
+  resources?: ComputeResource[]
+  free?: ComputeEnvironmentFreeOptions
+  platform: RunningPlatform
 }
 
 export interface ComputeEnvironment extends ComputeEnvironmentBaseConfig {
@@ -90,17 +85,18 @@ export interface C2DDockerConfig {
   caPath: string
   certPath: string
   keyPath: string
-  environments: ComputeEnvironment[]
+  storageExpiry?: number
+  maxJobDuration?: number
+  maxJobs?: number
+  fees: ComputeEnvFeesStructure
+  maxDisk: number
+  free?: ComputeEnvironmentFreeOptions
 }
 
 export interface ComputeEnvByChain {
   [chainId: number]: ComputeEnvironment[]
 }
 
-export interface ComputeResourceRequest {
-  type: string
-  amount: number
-}
 export type ComputeResultType =
   | 'algorithmLog'
   | 'output'
@@ -178,6 +174,8 @@ export interface DBComputeJob extends ComputeJob {
   isRunning: boolean
   isStarted: boolean
   containerImage: string
+  resources: ComputeResourceRequest[]
+  isFree: boolean
 }
 
 // make sure we keep them both in sync

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -45,7 +45,7 @@ export interface ComputeEnvFees {
   prices: ComputeResourcesPricingInfo[]
 }
 export interface ComputeEnvFeesStructure {
-  [chainId: string]: ComputeEnvFees
+  [chainId: string]: ComputeEnvFees[]
 }
 
 export interface RunningPlatform {
@@ -91,10 +91,6 @@ export interface C2DDockerConfig {
   fees: ComputeEnvFeesStructure
   maxDisk: number
   free?: ComputeEnvironmentFreeOptions
-}
-
-export interface ComputeEnvByChain {
-  [chainId: number]: ComputeEnvironment[]
 }
 
 export type ComputeResultType =

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -20,13 +20,18 @@ export interface C2DClusterInfo {
   tempFolder?: string
 }
 
-export type ComputeResourceType = 'cpu' | 'memory' | 'storage'
+// export type ComputeResourceType = 'cpu' | 'memory' | 'storage'
 
 export interface ComputeResourcesPricingInfo {
-  type: ComputeResourceType
+  id: string
   price: number
 }
 
+export interface ComputeResources {
+  id: string
+  type?: string
+  kind?: string
+}
 export interface ComputeEnvFees {
   feeToken: string
   prices: ComputeResourcesPricingInfo[]
@@ -37,39 +42,44 @@ export interface ComputeEnvFeesStructure {
 
 export interface RunningPlatform {
   architecture: string
-  os: string
+  os?: string
+}
+
+export interface ComputeEnvironmentFreeOptions {
+  // only if a compute env exposes free jobs
+  maxCpu?: number // max cpu for a single job.
+  maxRam?: number // max allocatable RAM for a single job in bytes.
+  maxDisk?: number // max disk space in bytes allocatable for a single job
+  storageExpiry?: number
+  maxJobDuration?: number
+  maxJobs: number // maximum number of free jobs in the same time
 }
 export interface ComputeEnvironmentBaseConfig {
   // cpuNumber: number
   // ramGB: number
   // diskGB: number
-  description: string // v1
+  description?: string // v1
   // maxJobs: number
   storageExpiry: number // v1
   maxJobDuration: number // v1 max seconds for a job
   // chainId?: number
   // feeToken: string
   // priceMin: number
-  totalCpu: number // total cpu available for jobs
-  maxCpu: number // max cpu for a single job.  Imagine a K8 cluster with two nodes, each node with 10 cpus.  Total=20, but at most you can allocate 10 cpu for a job
-  totalRam: number // total gb of RAM
-  maxRam: number // max allocatable GB RAM for a single job.
-  maxDisk: number // max GB of disck allocatable for a single job
+  totalCpu?: number // total cpu available for jobs
+  totalRam?: number // total bytes of RAM
+  maxCpu?: number // max cpu for a single job.  Imagine a K8 cluster with two nodes, each node with 10 cpus.  Total=20, but at most you can allocate 10 cpu for a job
+  maxRam?: number // max allocatable RAM for a single job in bytes.
+  maxDisk?: number // max disk space in bytes allocatable for a single job
+  free?: ComputeEnvironmentFreeOptions
   fees: ComputeEnvFeesStructure
+  resources?: ComputeResources[]
+  platform?: RunningPlatform[]
 }
 
 export interface ComputeEnvironment extends ComputeEnvironmentBaseConfig {
   id: string // v1
-  // arch: string => part of platform bellow
-  // cpuType?: string
-  // gpuNumber?: number
-  // gpuType?: string
-  chainId?: number // it can be useful to keep the chain id (optional)
   currentJobs: number
   consumerAddress: string // v1
-  // lastSeen?: number
-  free: boolean
-  platform?: RunningPlatform[] // array due to k8 support
 }
 
 export interface C2DDockerConfig {
@@ -81,7 +91,6 @@ export interface C2DDockerConfig {
   certPath: string
   keyPath: string
   environments: ComputeEnvironment[]
-  freeComputeOptions?: ComputeEnvironment
 }
 
 export interface ComputeEnvByChain {

--- a/src/@types/commands.ts
+++ b/src/@types/commands.ts
@@ -1,7 +1,12 @@
 import { ValidateParams } from '../components/httpRoutes/validateCommands.js'
 import { DDO } from './DDO/DDO'
 import { P2PCommandResponse } from './OceanNode'
-import type { ComputeAsset, ComputeAlgorithm, ComputeOutput } from './C2D/C2D.js'
+import type {
+  ComputeAsset,
+  ComputeAlgorithm,
+  ComputeOutput,
+  ComputeResourceRequest
+} from './C2D/C2D.js'
 import {
   ArweaveFileObject,
   FileObjectType,
@@ -166,14 +171,18 @@ export interface ComputeStartCommand extends Command {
   algorithm: ComputeAlgorithm
   datasets?: ComputeAsset[]
   output?: ComputeOutput
+  resources?: ComputeResourceRequest[]
+  chainId?: number // network used by payment
 }
 export interface FreeComputeStartCommand extends Command {
   consumerAddress: string
   signature: string
   nonce: string
+  environment: string
   algorithm: ComputeAlgorithm
   datasets?: ComputeAsset[]
   output?: ComputeOutput
+  resources?: ComputeResourceRequest[]
 }
 
 export interface ComputeStopCommand extends Command {

--- a/src/OceanNode.ts
+++ b/src/OceanNode.ts
@@ -79,6 +79,7 @@ export class OceanNode {
         return
       }
       this.c2dEngines = new C2DEngines(_config, this.db.c2d)
+      await this.c2dEngines.startAllEngines()
     }
   }
 

--- a/src/components/c2d/compute_engine_base.ts
+++ b/src/components/c2d/compute_engine_base.ts
@@ -31,12 +31,12 @@ export abstract class C2DEngine {
 
   // overwritten by classes for start actions
   public start(): Promise<void> {
-    throw new Error('Method not implemented.')
+    return null
   }
 
   // overwritten by classes for cleanup
   public stop(): Promise<void> {
-    throw new Error('Method not implemented.')
+    return null
   }
 
   public abstract startComputeJob(

--- a/src/components/c2d/compute_engine_base.ts
+++ b/src/components/c2d/compute_engine_base.ts
@@ -12,8 +12,6 @@ import type {
   DBComputeJob
 } from '../../@types/C2D/C2D.js'
 import { C2DClusterType } from '../../@types/C2D/C2D.js'
-import { isDefined } from '../../utils/util.js'
-import { cp } from 'fs'
 
 export abstract class C2DEngine {
   private clusterConfig: C2DClusterInfo

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -177,12 +177,12 @@ export class C2DEngineDocker extends C2DEngine {
     for (const computeEnv of this.envs) {
       if (!chainId) filteredEnvs.push(computeEnv)
       else {
-        if (computeEnv.fees && Object.hasOwn(computeEnv.fees, String(chainId))) {
+        if (computeEnv.fees && Object.hasOwn(computeEnv.fees, String(chainId)))
           filteredEnvs.push(computeEnv)
-        }
       }
     }
-    return this.envs
+
+    return filteredEnvs
   }
 
   /**

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -101,6 +101,10 @@ export class C2DEngineDocker extends C2DEngine {
       },
       fees: envConfig.fees ? envConfig.fees : null
     })
+    if (`storageExpiry` in envConfig) this.envs[0].storageExpiry = envConfig.storageExpiry
+    if (`maxJobDuration` in envConfig)
+      this.envs[0].maxJobDuration = envConfig.maxJobDuration
+    if (`maxJobs` in envConfig) this.envs[0].maxJobs = envConfig.maxJobs
     // let's add resources
     this.envs[0].resources = []
     this.envs[0].resources.push({

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -41,6 +41,7 @@ import * as drc from 'docker-registry-client'
 import { ValidateParams } from '../httpRoutes/validateCommands.js'
 import { convertGigabytesToBytes } from '../../utils/util.js'
 import os from 'os'
+import { runInThisContext } from 'node:vm'
 
 export class C2DEngineDocker extends C2DEngine {
   private envs: ComputeEnvironment[] = []
@@ -97,6 +98,10 @@ export class C2DEngineDocker extends C2DEngine {
     console.log(sysinfo)
     console.log(this.envs)
     for (const i in this.envs) {
+      if (!('id' in this.envs[i]) || !this.envs[i].id) {
+        this.envs[i].id =
+          this.getC2DConfig().hash + '-' + create256Hash(JSON.stringify(this.envs[i]))
+      }
       if (!('platform' in this.envs[i]))
         this.envs[i].platform = [{ architecture: null, os: null }]
       this.envs[i].platform[0].architecture = sysinfo.Architecture

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -895,54 +895,62 @@ export class C2DEngineDocker extends C2DEngine {
       this.getC2DConfig().tempFolder + '/' + job.jobId + '/data/transformations/algorithm'
     try {
       let storage = null
-      // do we have a files object?
-      if (job.algorithm.fileObject) {
-        // is it unencrypted?
-        if (job.algorithm.fileObject.type) {
-          // we can get the storage directly
-          storage = Storage.getStorageClass(job.algorithm.fileObject, config)
+
+      if (job.algorithm.meta.rawcode && job.algorithm.meta.rawcode.length > 0) {
+        // we have the code, just write it
+        writeFileSync(fullAlgoPath, job.algorithm.meta.rawcode)
+      } else {
+        // do we have a files object?
+        if (job.algorithm.fileObject) {
+          // is it unencrypted?
+          if (job.algorithm.fileObject.type) {
+            // we can get the storage directly
+            storage = Storage.getStorageClass(job.algorithm.fileObject, config)
+          } else {
+            // ok, maybe we have this encrypted instead
+            CORE_LOGGER.info(
+              'algorithm file object seems to be encrypted, checking it...'
+            )
+            // 1. Decrypt the files object
+            const decryptedFileObject = await decryptFilesObject(job.algorithm.fileObject)
+            console.log('decryptedFileObject: ', decryptedFileObject)
+            // 2. Get default storage settings
+            storage = Storage.getStorageClass(decryptedFileObject, config)
+          }
         } else {
-          // ok, maybe we have this encrypted instead
-          CORE_LOGGER.info('algorithm file object seems to be encrypted, checking it...')
-          // 1. Decrypt the files object
-          const decryptedFileObject = await decryptFilesObject(job.algorithm.fileObject)
-          console.log('decryptedFileObject: ', decryptedFileObject)
-          // 2. Get default storage settings
-          storage = Storage.getStorageClass(decryptedFileObject, config)
-        }
-      } else {
-        // no files object, try to get information from documentId and serviceId
-        CORE_LOGGER.info(
-          'algorithm file object seems to be missing, checking "serviceId" and "documentId"...'
-        )
-        const { serviceId, documentId } = job.algorithm
-        // we can get it from this info
-        if (serviceId && documentId) {
-          const algoDdo = await new FindDdoHandler(
-            OceanNode.getInstance()
-          ).findAndFormatDdo(documentId)
-          console.log('algo ddo:', algoDdo)
-          // 1. Get the service
-          const service: Service = AssetUtils.getServiceById(algoDdo, serviceId)
+          // no files object, try to get information from documentId and serviceId
+          CORE_LOGGER.info(
+            'algorithm file object seems to be missing, checking "serviceId" and "documentId"...'
+          )
+          const { serviceId, documentId } = job.algorithm
+          // we can get it from this info
+          if (serviceId && documentId) {
+            const algoDdo = await new FindDdoHandler(
+              OceanNode.getInstance()
+            ).findAndFormatDdo(documentId)
+            console.log('algo ddo:', algoDdo)
+            // 1. Get the service
+            const service: Service = AssetUtils.getServiceById(algoDdo, serviceId)
 
-          // 2. Decrypt the files object
-          const decryptedFileObject = await decryptFilesObject(service.files)
-          console.log('decryptedFileObject: ', decryptedFileObject)
-          // 4. Get default storage settings
-          storage = Storage.getStorageClass(decryptedFileObject, config)
+            // 2. Decrypt the files object
+            const decryptedFileObject = await decryptFilesObject(service.files)
+            console.log('decryptedFileObject: ', decryptedFileObject)
+            // 4. Get default storage settings
+            storage = Storage.getStorageClass(decryptedFileObject, config)
+          }
         }
-      }
 
-      if (storage) {
-        console.log('fullAlgoPath', fullAlgoPath)
-        await pipeline(
-          (await storage.getReadableStream()).stream,
-          createWriteStream(fullAlgoPath)
-        )
-      } else {
-        CORE_LOGGER.info(
-          'Could not extract any files object from the compute algorithm, skipping...'
-        )
+        if (storage) {
+          console.log('fullAlgoPath', fullAlgoPath)
+          await pipeline(
+            (await storage.getReadableStream()).stream,
+            createWriteStream(fullAlgoPath)
+          )
+        } else {
+          CORE_LOGGER.info(
+            'Could not extract any files object from the compute algorithm, skipping...'
+          )
+        }
       }
     } catch (e) {
       CORE_LOGGER.error(

--- a/src/components/c2d/compute_engine_opf_k8.ts
+++ b/src/components/c2d/compute_engine_opf_k8.ts
@@ -29,7 +29,7 @@ import { Storage } from '../storage/index.js'
 export class C2DEngineOPFK8 extends C2DEngine {
   // eslint-disable-next-line no-useless-constructor
   public constructor(clusterConfig: C2DClusterInfo) {
-    super(clusterConfig)
+    super(clusterConfig, null)
   }
 
   public override async getComputeEnvironments(

--- a/src/components/c2d/compute_engines.ts
+++ b/src/components/c2d/compute_engines.ts
@@ -1,7 +1,7 @@
 import { C2DClusterType, ComputeEnvironment } from '../../@types/C2D/C2D.js'
 import { C2DEngine } from './compute_engine_base.js'
 import { C2DEngineOPFK8 } from './compute_engine_opf_k8.js'
-import { C2DEngineDocker, C2DEngineDockerFree } from './compute_engine_docker.js'
+import { C2DEngineDocker } from './compute_engine_docker.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { C2DDatabase } from '../database/C2DDatabase.js'
 export class C2DEngines {
@@ -10,7 +10,9 @@ export class C2DEngines {
   public constructor(config: OceanNodeConfig, db: C2DDatabase) {
     // let's see what engines do we have and initialize them one by one
     // for docker, we need to add the "free"
-    let haveFree = false
+
+    // TO DO - check if we have multiple config.c2dClusters with the same host
+    // if yes, do not create multiple engines
     if (config && config.c2dClusters) {
       this.engines = []
       for (const cluster of config.c2dClusters) {
@@ -19,10 +21,6 @@ export class C2DEngines {
         }
         if (cluster.type === C2DClusterType.DOCKER) {
           this.engines.push(new C2DEngineDocker(cluster, db))
-          if (!haveFree) {
-            this.engines.push(new C2DEngineDockerFree(cluster, db))
-            haveFree = true
-          }
         }
       }
     }

--- a/src/components/c2d/index.ts
+++ b/src/components/c2d/index.ts
@@ -1,13 +1,5 @@
-import { OceanNode } from '../../OceanNode.js'
-import { getConfiguration } from '../../utils/config.js'
-import { ComputeGetEnvironmentsHandler } from '../core/compute/index.js'
-import { PROTOCOL_COMMANDS } from '../../utils/constants.js'
-import {
-  deleteKeysFromObject,
-  sanitizeServiceFiles,
-  streamToObject
-} from '../../utils/util.js'
-import { Readable } from 'stream'
+import { deleteKeysFromObject, sanitizeServiceFiles } from '../../utils/util.js'
+
 import { decrypt } from '../../utils/crypt.js'
 import { BaseFileObject, EncryptMethod } from '../../@types/fileObject.js'
 import { CORE_LOGGER } from '../../utils/logging/common.js'

--- a/src/components/c2d/index.ts
+++ b/src/components/c2d/index.ts
@@ -14,32 +14,6 @@ import { CORE_LOGGER } from '../../utils/logging/common.js'
 import { ComputeJob, DBComputeJob } from '../../@types/index.js'
 export { C2DEngine } from './compute_engine_base.js'
 
-export async function checkC2DEnvExists(
-  envId: string,
-  oceanNode: OceanNode
-): Promise<boolean> {
-  const config = await getConfiguration()
-  const { supportedNetworks } = config
-  for (const supportedNetwork of Object.keys(supportedNetworks)) {
-    const getEnvironmentsTask = {
-      command: PROTOCOL_COMMANDS.COMPUTE_GET_ENVIRONMENTS,
-      chainId: parseInt(supportedNetwork)
-    }
-    const response = await new ComputeGetEnvironmentsHandler(oceanNode).handle(
-      getEnvironmentsTask
-    )
-    if (response.status.httpStatus === 200) {
-      const computeEnvironments = await streamToObject(response.stream as Readable)
-      for (const computeEnvironment of computeEnvironments[parseInt(supportedNetwork)]) {
-        if (computeEnvironment.id === envId) {
-          return true
-        }
-      }
-    }
-  }
-  return false
-}
-
 export async function decryptFilesObject(
   serviceFiles: any
 ): Promise<BaseFileObject | null> {

--- a/src/components/core/compute/environments.ts
+++ b/src/components/core/compute/environments.ts
@@ -1,10 +1,8 @@
 import { Readable } from 'stream'
 import { P2PCommandResponse } from '../../../@types/index.js'
-import { ComputeEnvByChain } from '../../../@types/C2D/C2D.js'
 import { CORE_LOGGER } from '../../../utils/logging/common.js'
 import { Handler } from '../handler/handler.js'
 import { ComputeGetEnvironmentsCommand } from '../../../@types/commands.js'
-import { getConfiguration } from '../../../utils/config.js'
 import {
   ValidateParams,
   buildInvalidRequestMessage,
@@ -27,14 +25,8 @@ export class ComputeGetEnvironmentsHandler extends Handler {
       return validationResponse
     }
     try {
-      const result: ComputeEnvByChain = {}
       const computeEngines = this.getOceanNode().getC2DEngines()
-      const config = await getConfiguration()
-      for (const chain of Object.keys(config.supportedNetworks)) {
-        const chainId = parseInt(chain)
-        if (task.chainId && task.chainId !== chainId) continue
-        result[chainId] = await computeEngines.fetchEnvironments(chainId)
-      }
+      const result = await computeEngines.fetchEnvironments(task.chainId)
 
       CORE_LOGGER.logMessage(
         'ComputeGetEnvironmentsCommand Response: ' + JSON.stringify(result, null, 2),

--- a/src/components/core/compute/initialize.ts
+++ b/src/components/core/compute/initialize.ts
@@ -146,7 +146,7 @@ export class ComputeInitializeHandler extends Handler {
                 .getExactComputeEnv(task.compute.env, ddo.chainId)
               const validation: ValidateParams = await C2DEngineDocker.checkDockerImage(
                 algoImage,
-                env.platform && env.platform.length > 0 ? env.platform[0] : null
+                env.platform
               )
               if (!validation.valid) {
                 return {

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -28,7 +28,6 @@ import { FindDdoHandler } from '../handler/ddoHandler.js'
 import { ProviderFeeValidation } from '../../../@types/Fees.js'
 import { isOrderingAllowedForAsset } from '../handler/downloadHandler.js'
 import { getNonceAsNumber } from '../utils/nonceHandler.js'
-import { env } from 'process'
 export class ComputeStartHandler extends Handler {
   validate(command: ComputeStartCommand): ValidateParams {
     const commandValidation = validateCommandParameters(command, [

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -28,6 +28,7 @@ import { FindDdoHandler } from '../handler/ddoHandler.js'
 import { ProviderFeeValidation } from '../../../@types/Fees.js'
 import { isOrderingAllowedForAsset } from '../handler/downloadHandler.js'
 import { getNonceAsNumber } from '../utils/nonceHandler.js'
+import { env } from 'process'
 export class ComputeStartHandler extends Handler {
   validate(command: ComputeStartCommand): ValidateParams {
     const commandValidation = validateCommandParameters(command, [
@@ -68,6 +69,24 @@ export class ComputeStartHandler extends Handler {
           status: {
             httpStatus: 500,
             error: 'Invalid C2D Environment'
+          }
+        }
+      }
+
+      try {
+        const env = await engine.getComputeEnvironment(null, task.environment)
+        task.resources = await engine.checkAndFillMissingResources(
+          task.resources,
+          env,
+          false
+        )
+        await engine.hasResourcesAvailable(task.resources, env, true)
+      } catch (e) {
+        return {
+          stream: null,
+          status: {
+            httpStatus: 400,
+            error: e
           }
         }
       }
@@ -323,7 +342,8 @@ export class ComputeStartHandler extends Handler {
         task.consumerAddress,
         validUntil,
         chainId,
-        agreementId
+        agreementId,
+        task.resources
       )
 
       CORE_LOGGER.logMessage(
@@ -359,7 +379,8 @@ export class FreeComputeStartHandler extends Handler {
       'datasets',
       'consumerAddress',
       'signature',
-      'nonce'
+      'nonce',
+      'environment'
     ])
     if (commandValidation.valid) {
       if (!isAddress(command.consumerAddress)) {
@@ -376,32 +397,70 @@ export class FreeComputeStartHandler extends Handler {
     if (this.shouldDenyTaskHandling(validationResponse)) {
       return validationResponse
     }
-    let environment = null
+    let engine = null
     try {
-      // get all envs and see if we have a free one
-      const allEnvs = await this.getOceanNode().getC2DEngines().fetchEnvironments()
-      for (const env of allEnvs) {
-        // if (env.free) {
-        environment = env
-        // }
-      }
-      if (!environment)
+      // split compute env (which is already in hash-envId format) and get the hash
+      // then get env which might contain dashes as well
+      const eIndex = task.environment.indexOf('-')
+      const hash = task.environment.slice(0, eIndex)
+      // const envId = task.environment.slice(eIndex + 1)
+      try {
+        engine = await this.getOceanNode().getC2DEngines().getC2DByHash(hash)
+      } catch (e) {
         return {
           stream: null,
           status: {
             httpStatus: 500,
-            error: 'This node does not have a free compute env'
+            error: 'Invalid C2D Environment'
           }
         }
-      const engine = await this.getOceanNode()
-        .getC2DEngines()
-        .getC2DByEnvId(environment.id)
+      }
+      if (engine === null) {
+        return {
+          stream: null,
+          status: {
+            httpStatus: 500,
+            error: 'Invalid C2D Environment'
+          }
+        }
+      }
+      try {
+        const env = await engine.getComputeEnvironment(null, task.environment)
+        task.resources = await engine.checkAndFillMissingResources(
+          task.resources,
+          env,
+          true
+        )
+        await engine.hasResourcesAvailable(task.resources, env, true)
+      } catch (e) {
+        console.error(e)
+        return {
+          stream: null,
+          status: {
+            httpStatus: 400,
+            error: String(e)
+          }
+        }
+      }
+      // console.log(task.resources)
+      /*
+      return {
+        stream: null,
+        status: {
+          httpStatus: 200,
+          error: null
+        }
+      } */
       const response = await engine.startComputeJob(
         task.datasets,
         task.algorithm,
         task.output,
-        environment.id,
-        task.consumerAddress
+        task.environment,
+        task.consumerAddress,
+        null,
+        null,
+        null,
+        task.resources
       )
 
       CORE_LOGGER.logMessage(

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -74,12 +74,21 @@ export class ComputeStartHandler extends Handler {
 
       try {
         const env = await engine.getComputeEnvironment(null, task.environment)
+        if (!env) {
+          return {
+            stream: null,
+            status: {
+              httpStatus: 500,
+              error: 'Invalid C2D Environment'
+            }
+          }
+        }
         task.resources = await engine.checkAndFillMissingResources(
           task.resources,
           env,
           false
         )
-        await engine.hasResourcesAvailable(task.resources, env, true)
+        await engine.checkIfResourcesAreAvailable(task.resources, env, true)
       } catch (e) {
         return {
           stream: null,
@@ -425,12 +434,22 @@ export class FreeComputeStartHandler extends Handler {
       }
       try {
         const env = await engine.getComputeEnvironment(null, task.environment)
+        if (!env) {
+          return {
+            stream: null,
+            status: {
+              httpStatus: 500,
+              error: 'Invalid C2D Environment'
+            }
+          }
+        }
+
         task.resources = await engine.checkAndFillMissingResources(
           task.resources,
           env,
           true
         )
-        await engine.hasResourcesAvailable(task.resources, env, true)
+        await engine.checkIfResourcesAreAvailable(task.resources, env, true)
       } catch (e) {
         console.error(e)
         return {

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -223,16 +223,6 @@ export class ComputeStartHandler extends Handler {
           result.chainId = ddo.chainId
 
           const env = await engine.getComputeEnvironment(ddo.chainId, task.environment)
-          if (env.free) {
-            const error = `Free Jobs cannot be started here, use startFreeCompute`
-            return {
-              stream: null,
-              status: {
-                httpStatus: 500,
-                error
-              }
-            }
-          }
           if (!('transferTxId' in elem) || !elem.transferTxId) {
             const error = `Missing transferTxId for DDO ${elem.documentId}`
             return {
@@ -391,9 +381,9 @@ export class FreeComputeStartHandler extends Handler {
       // get all envs and see if we have a free one
       const allEnvs = await this.getOceanNode().getC2DEngines().fetchEnvironments()
       for (const env of allEnvs) {
-        if (env.free) {
-          environment = env
-        }
+        // if (env.free) {
+        environment = env
+        // }
       }
       if (!environment)
         return {

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -27,7 +27,8 @@ import { sanitizeServiceFiles } from '../../../utils/util.js'
 import { FindDdoHandler } from '../handler/ddoHandler.js'
 import { ProviderFeeValidation } from '../../../@types/Fees.js'
 import { isOrderingAllowedForAsset } from '../handler/downloadHandler.js'
-import { getNonceAsNumber } from '../utils/nonceHandler.js'
+import { checkNonce, NonceResponse, getNonceAsNumber } from '../utils/nonceHandler.js'
+
 export class ComputeStartHandler extends Handler {
   validate(command: ComputeStartCommand): ValidateParams {
     const commandValidation = validateCommandParameters(command, [
@@ -405,6 +406,30 @@ export class FreeComputeStartHandler extends Handler {
     if (this.shouldDenyTaskHandling(validationResponse)) {
       return validationResponse
     }
+    const thisNode = this.getOceanNode()
+    // Validate nonce and signature
+    const nonceCheckResult: NonceResponse = await checkNonce(
+      thisNode.getDatabase().nonce,
+      task.consumerAddress,
+      parseInt(task.nonce),
+      task.signature,
+      String(task.nonce)
+    )
+
+    if (!nonceCheckResult.valid) {
+      CORE_LOGGER.logMessage(
+        'Invalid nonce or signature, unable to proceed: ' + nonceCheckResult.error,
+        true
+      )
+      return {
+        stream: null,
+        status: {
+          httpStatus: 500,
+          error:
+            'Invalid nonce or signature, unable to proceed: ' + nonceCheckResult.error
+        }
+      }
+    }
     let engine = null
     try {
       // split compute env (which is already in hash-envId format) and get the hash
@@ -413,7 +438,7 @@ export class FreeComputeStartHandler extends Handler {
       const hash = task.environment.slice(0, eIndex)
       // const envId = task.environment.slice(eIndex + 1)
       try {
-        engine = await this.getOceanNode().getC2DEngines().getC2DByHash(hash)
+        engine = await thisNode.getC2DEngines().getC2DByHash(hash)
       } catch (e) {
         return {
           stream: null,

--- a/src/components/core/utils/feesHandler.ts
+++ b/src/components/core/utils/feesHandler.ts
@@ -56,7 +56,7 @@ async function calculateProviderFeeAmount(
   if (computeEnv) {
     if (computeEnv.fees) {
       // get the fess for the asset chain
-      const feesForChain: ComputeEnvFees = computeEnv.fees[chainId]
+      const feesForChain: ComputeEnvFees = computeEnv.fees[chainId][0]
       if (feesForChain && feesForChain.prices.length > 0) {
         const price =
           // TODO: check this again
@@ -98,7 +98,7 @@ export async function createProviderFee(
   const providerFeeAddress: string = providerWallet.address
   let providerFeeAmount: number
   let providerFeeAmountFormatted: BigNumberish
-
+  // TO DO - this will be overwritten with new escrow anyay
   let providerFeeToken: string
   if (
     computeEnv &&
@@ -106,7 +106,7 @@ export async function createProviderFee(
     Object.hasOwn(computeEnv.fees, String(asset.chainId))
   ) {
     // was: if (computeEnv)
-    providerFeeToken = computeEnv.fees[asset.chainId].feeToken // was: computeEnv.feeToken
+    providerFeeToken = computeEnv.fees[asset.chainId][0].feeToken // was: computeEnv.feeToken
   } else {
     // it's download, take it from config
     providerFeeToken = await getProviderFeeToken(asset.chainId)

--- a/src/components/core/utils/feesHandler.ts
+++ b/src/components/core/utils/feesHandler.ts
@@ -1,8 +1,7 @@
 import type {
   ComputeEnvFees,
   ComputeEnvironment,
-  ComputeResourcesPricingInfo,
-  ComputeResourceType
+  ComputeResourcesPricingInfo
 } from '../../../@types/C2D/C2D.js'
 import {
   JsonRpcApiProvider,
@@ -33,12 +32,12 @@ import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/template
 import { fetchEventFromTransaction } from '../../../utils/util.js'
 import { fetchTransactionReceipt } from './validateOrders.js'
 
-export function getEnvironmentPriceSchemaForType(
+export function getEnvironmentPriceSchemaForResource(
   prices: ComputeResourcesPricingInfo[],
-  type: ComputeResourceType
+  id: string
 ): number {
   for (const pr of prices) {
-    if (pr.type === type) {
+    if (pr.id === id) {
       return pr.price
     }
   }
@@ -62,9 +61,9 @@ async function calculateProviderFeeAmount(
         const price =
           // TODO: check this again
           // try to get the price from the SUM of the available types; 'cpu', 'memory' or 'storage'
-          getEnvironmentPriceSchemaForType(feesForChain.prices, 'cpu') +
-          getEnvironmentPriceSchemaForType(feesForChain.prices, 'memory') +
-          getEnvironmentPriceSchemaForType(feesForChain.prices, 'storage')
+          getEnvironmentPriceSchemaForResource(feesForChain.prices, 'cpu') +
+          getEnvironmentPriceSchemaForResource(feesForChain.prices, 'memory') +
+          getEnvironmentPriceSchemaForResource(feesForChain.prices, 'storage')
         // it's a compute provider fee
         providerFeeAmount = (seconds * parseFloat(String(price || 0))) / 60 // was: (seconds * parseFloat(String(computeEnv.priceMin))) / 60
       }

--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -33,7 +33,9 @@ function getInternalStructure(job: DBComputeJob): any {
     assets: job.assets,
     isRunning: job.isRunning,
     isStarted: job.isStarted,
-    containerImage: job.containerImage
+    containerImage: job.containerImage,
+    resources: job.resources,
+    isFree: job.isFree
   }
   return internalBlob
 }

--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -7,6 +7,7 @@ import {
 } from '../../@types/C2D/C2D.js'
 import sqlite3, { RunResult } from 'sqlite3'
 import { DATABASE_LOGGER } from '../../utils/logging/common.js'
+import { v4 as uuidv4 } from 'uuid'
 
 interface ComputeDatabaseProvider {
   newJob(job: DBComputeJob): Promise<string>
@@ -18,7 +19,7 @@ interface ComputeDatabaseProvider {
 }
 
 export function generateUniqueID(): string {
-  return crypto.randomUUID().toString()
+  return uuidv4()
 }
 
 function getInternalStructure(job: DBComputeJob): any {

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -68,13 +68,8 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeEnvironments`, async (req, r
     ) // get compute environments
     const computeEnvironments = await streamToObject(response.stream as Readable)
 
-    // check if computeEnvironments is a valid json object and not empty
-    if (computeEnvironments && computeEnvironments.length > 0) {
-      res.json(computeEnvironments)
-    } else {
-      HTTP_LOGGER.logMessage(`Compute environments not found`, true)
-      res.status(404).send('Compute environments not found')
-    }
+    // always return the array, even if it's empty
+    res.json(computeEnvironments)
   } catch (error) {
     HTTP_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error: ${error}`)
     res.status(500).send('Internal Server Error')

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -69,10 +69,7 @@ computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeEnvironments`, async (req, r
     const computeEnvironments = await streamToObject(response.stream as Readable)
 
     // check if computeEnvironments is a valid json object and not empty
-    if (
-      computeEnvironments &&
-      !(await areEmpty(computeEnvironments, req.query.chainId))
-    ) {
+    if (computeEnvironments && computeEnvironments.length > 0) {
       res.json(computeEnvironments)
     } else {
       HTTP_LOGGER.logMessage(`Compute environments not found`, true)

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -29,28 +29,8 @@ import { PROTOCOL_COMMANDS, SERVICES_API_BASE_PATH } from '../../utils/constants
 import { Readable } from 'stream'
 import { HTTP_LOGGER } from '../../utils/logging/common.js'
 import { LOG_LEVELS_STR } from '../../utils/logging/Logger.js'
-import { getConfiguration } from '../../utils/index.js'
 
 export const computeRoutes = express.Router()
-
-async function areEmpty(computeEnvs: any, requestChainId?: any): Promise<boolean> {
-  if (requestChainId) {
-    return computeEnvs[parseInt(requestChainId)].length === 0
-  } else {
-    const config = await getConfiguration()
-    let isEmpty: number = 0
-    const supportedNetworks = Object.keys(config.supportedNetworks)
-    for (const supportedNetwork of supportedNetworks) {
-      if (computeEnvs[supportedNetwork].length === 0) {
-        isEmpty++
-      }
-    }
-    if (isEmpty === supportedNetworks.length) {
-      return true
-    }
-    return false
-  }
-}
 
 computeRoutes.get(`${SERVICES_API_BASE_PATH}/computeEnvironments`, async (req, res) => {
   try {

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -12,7 +12,8 @@ import {
 import type {
   ComputeAlgorithm,
   ComputeAsset,
-  ComputeOutput
+  ComputeOutput,
+  ComputeResourceRequest
 } from '../../@types/C2D/C2D.js'
 import type {
   ComputeStartCommand,
@@ -99,7 +100,8 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/compute`, async (req, res) => {
       nonce: (req.body.nonce as string) || null,
       environment: (req.body.environment as string) || null,
       algorithm: (req.body.algorithm as ComputeAlgorithm) || null,
-      datasets: (req.body.datasets as unknown as ComputeAsset[]) || null
+      datasets: (req.body.datasets as unknown as ComputeAsset[]) || null,
+      resources: (req.body.resources as unknown as ComputeResourceRequest[]) || null
     }
     if (req.body.output) {
       startComputeTask.output = req.body.output as ComputeOutput
@@ -135,8 +137,10 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/freeCompute`, async (req, res) => 
       consumerAddress: (req.body.consumerAddress as string) || null,
       signature: (req.body.signature as string) || null,
       nonce: (req.body.nonce as string) || null,
+      environment: (req.body.environment as string) || null,
       algorithm: (req.body.algorithm as ComputeAlgorithm) || null,
-      datasets: (req.body.datasets as unknown as ComputeAsset[]) || null
+      datasets: (req.body.datasets as unknown as ComputeAsset[]) || null,
+      resources: (req.body.resources as unknown as ComputeResourceRequest[]) || null
     }
     if (req.body.output) {
       startComputeTask.output = req.body.output as ComputeOutput

--- a/src/test/data/assets.ts
+++ b/src/test/data/assets.ts
@@ -253,6 +253,7 @@ export const algoAsset = {
         files: [
           {
             type: 'url',
+            method: 'GET',
             url: 'https://raw.githubusercontent.com/oceanprotocol/test-algorithm/master/javascript/algo.js',
             contentType: 'text/js',
             encoding: 'UTF-8'

--- a/src/test/data/commands.ts
+++ b/src/test/data/commands.ts
@@ -1,6 +1,7 @@
 export const freeComputeStartPayload = {
   command: 'freeStartCompute',
   consumerAddress: '0xC7EC1970B09224B317c52d92f37F5e1E4fF6B687',
+  environment: '',
   nonce: '1',
   signature: '0x123',
   datasets: [

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -1,22 +1,22 @@
 import { expect, assert } from 'chai'
 import {
   ComputeGetEnvironmentsHandler,
-  ComputeStartHandler,
+  // ComputeStartHandler,
   ComputeStopHandler,
   ComputeGetStatusHandler,
-  ComputeInitializeHandler,
+  // ComputeInitializeHandler,
   FreeComputeStartHandler
 } from '../../components/core/compute/index.js'
 import type {
   ComputeStartCommand,
   ComputeStopCommand,
   ComputeGetStatusCommand,
-  ComputeInitializeCommand,
+  // ComputeInitializeCommand,
   FreeComputeStartCommand
 } from '../../@types/commands.js'
 import type {
-  ComputeAsset,
-  ComputeAlgorithm,
+  // ComputeAsset,
+  // ComputeAlgorithm,
   ComputeEnvironment
 } from '../../@types/C2D/C2D.js'
 import {
@@ -42,7 +42,8 @@ import {
   Signer,
   ZeroAddress
 } from 'ethers'
-import { publishAsset, orderAsset } from '../utils/assets.js'
+// import { publishAsset, orderAsset } from '../utils/assets.js'
+import { publishAsset } from '../utils/assets.js'
 import { computeAsset, algoAsset } from '../data/assets.js'
 import { RPCS } from '../../@types/blockchain.js'
 import {
@@ -55,7 +56,7 @@ import {
   tearDownEnvironment
 } from '../utils/utils.js'
 
-import { ProviderFees } from '../../@types/Fees.js'
+// import { ProviderFees } from '../../@types/Fees.js'
 import { homedir } from 'os'
 import { publishAlgoDDO, publishDatasetDDO } from '../data/ddo.js'
 import { DEVELOPMENT_CHAIN_ID, getOceanArtifactsAdresses } from '../../utils/address.js'
@@ -78,18 +79,18 @@ describe('Compute', () => {
   let oceanNode: OceanNode
   let provider: any
   let publisherAccount: any
-  let consumerAccount: any
+  // let consumerAccount: any
   let computeEnvironments: any
   let publishedComputeDataset: any
   let publishedAlgoDataset: any
   let jobId: string
   let datasetOrderTxId: any
   let algoOrderTxId: any
-  let providerFeesComputeDataset: ProviderFees
-  let providerFeesComputeAlgo: ProviderFees
+  // let providerFeesComputeDataset: ProviderFees
+  // let providerFeesComputeAlgo: ProviderFees
   let indexer: OceanIndexer
-  const now = new Date().getTime() / 1000
-  const computeJobValidUntil = now + 60 * 15 // 15 minutes from now should be enough
+  // const now = new Date().getTime() / 1000
+  // const computeJobValidUntil = now + 60 * 15 // 15 minutes from now should be enough
   let firstEnv: ComputeEnvironment
 
   const wallet = new ethers.Wallet(
@@ -140,7 +141,7 @@ describe('Compute', () => {
 
     provider = new JsonRpcProvider('http://127.0.0.1:8545')
     publisherAccount = (await provider.getSigner(0)) as Signer
-    consumerAccount = (await provider.getSigner(1)) as Signer
+    // consumerAccount = (await provider.getSigner(1)) as Signer
 
     const artifactsAddresses = getOceanArtifactsAdresses()
     publisherAddress = await publisherAccount.getAddress()

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -579,8 +579,7 @@ describe('Compute', () => {
   it('should start a compute job', async () => {
     // first need to check the existing envs
     // If only FREE envs than start a free compute job instead of a regular/payed one
-    const hasOnlyFreeEnv =
-      computeEnvironments[DEVELOPMENT_CHAIN_ID].length === 1 && firstEnv.free
+    const hasOnlyFreeEnv = computeEnvironments[DEVELOPMENT_CHAIN_ID].length === 1 // && firstEnv.free
 
     const nonce = Date.now().toString()
     const message = String(nonce)

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -725,8 +725,32 @@ describe('Compute', () => {
     assert(response.stream, 'Failed to get stream')
     expect(response.stream).to.be.instanceOf(Readable)
   })
-  it('should deny the Free job due to bad container image (directCommand payload)', async function () {
+  it('should deny the Free job due to signature (directCommand payload)', async function () {
     freeComputeStartPayload.environment = firstEnv.id
+    const command: FreeComputeStartCommand = freeComputeStartPayload
+    const handler = new FreeComputeStartHandler(oceanNode)
+    const response = await handler.handle(command)
+    assert(response.status.httpStatus === 500, 'Failed to get 500 response')
+    assert(response.stream === null, 'Should not get stream')
+    assert(
+      response.status.error.includes('Invalid nonce or signature'),
+      'Should have signature error'
+    )
+  })
+  it('should deny the Free job due to bad container image (directCommand payload)', async function () {
+    const nonce = Date.now().toString()
+    const message = String(nonce)
+    // sign message/nonce
+    const consumerMessage = ethers.solidityPackedKeccak256(
+      ['bytes'],
+      [ethers.hexlify(ethers.toUtf8Bytes(message))]
+    )
+    const messageHashBytes = ethers.toBeArray(consumerMessage)
+    const signature = await wallet.signMessage(messageHashBytes)
+    freeComputeStartPayload.signature = signature
+    freeComputeStartPayload.nonce = nonce
+    freeComputeStartPayload.environment = firstEnv.id
+    freeComputeStartPayload.consumerAddress = await wallet.getAddress()
     const command: FreeComputeStartCommand = freeComputeStartPayload
     const handler = new FreeComputeStartHandler(oceanNode)
     const response = await handler.handle(command)

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -64,7 +64,6 @@ import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templat
 import { createHash } from 'crypto'
 import { encrypt } from '../../utils/crypt.js'
 import { EncryptMethod } from '../../@types/fileObject.js'
-import { checkC2DEnvExists } from '../../components/c2d/index.js'
 import {
   getAlgoChecksums,
   validateAlgoForDataset
@@ -98,7 +97,7 @@ describe('Compute', () => {
   )
   // const chainId = DEVELOPMENT_CHAIN_ID
   const mockSupportedNetworks: RPCS = getMockSupportedNetworks()
-  const chainId = 8996
+  const chainId = DEVELOPMENT_CHAIN_ID
   // randomly use a set of trusted algos or empty arrays
   // should validate if set and match, invalidate otherwise
   const setTrustedAlgosEmpty: boolean = Math.random() <= 0.5
@@ -118,19 +117,17 @@ describe('Compute', () => {
           ENVIRONMENT_VARIABLES.PRIVATE_KEY,
           ENVIRONMENT_VARIABLES.AUTHORIZED_DECRYPTERS,
           ENVIRONMENT_VARIABLES.ADDRESS_FILE,
-          // ENVIRONMENT_VARIABLES.OPERATOR_SERVICE_URL,
-          ENVIRONMENT_VARIABLES.DOCKER_SOCKET_PATH
-          // ENVIRONMENT_VARIABLES.DB_TYPE
+          ENVIRONMENT_VARIABLES.DOCKER_COMPUTE_ENVIRONMENTS
         ],
         [
           JSON.stringify(mockSupportedNetworks),
-          JSON.stringify([8996]),
+          JSON.stringify([DEVELOPMENT_CHAIN_ID]),
           '0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58',
           JSON.stringify(['0xe2DD09d719Da89e5a3D0F2549c7E24566e947260']),
           `${homedir}/.ocean/ocean-contracts/artifacts/address.json`,
-          // JSON.stringify(['http://localhost:31000']),
-          '/var/run/docker.sock'
-          // DB_TYPES.ELASTIC_SEARCH
+          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
+            DEVELOPMENT_CHAIN_ID +
+            '":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
         ]
       )
     )
@@ -259,28 +256,25 @@ describe('Compute', () => {
     computeEnvironments = await streamToObject(response.stream as Readable)
     console.log('existing envs: ', computeEnvironments)
     // expect 1 OR + envs (1 if only docker free env is available)
-    assert(computeEnvironments[DEVELOPMENT_CHAIN_ID].length >= 1, 'incorrect length')
-    for (const computeEnvironment of computeEnvironments[DEVELOPMENT_CHAIN_ID]) {
+    assert(computeEnvironments.length >= 1, 'Not enough compute envs')
+    for (const computeEnvironment of computeEnvironments) {
       assert(computeEnvironment.id, 'id missing in computeEnvironments')
+      assert(computeEnvironment.fees, 'fees missing in computeEnvironments')
       assert(
         computeEnvironment.consumerAddress,
         'consumerAddress missing in computeEnvironments'
       )
 
       assert(computeEnvironment.id.startsWith('0x'), 'id should start with 0x')
-
-      // new structure
-      assert(computeEnvironment.totalCpu > 0, 'totalCpu missing in computeEnvironments')
-      assert(computeEnvironment.totalRam > 0, 'totalRam missing in computeEnvironments')
-      assert(computeEnvironment.maxDisk > 0, 'maxDisk missing in computeEnvironments')
+      assert(computeEnvironment.resources.length > 2, 'Missing resources')
       assert(
         computeEnvironment.maxJobDuration > 0,
         'maxJobDuration missing in computeEnvironments'
       )
     }
-    firstEnv = computeEnvironments[DEVELOPMENT_CHAIN_ID][0]
+    firstEnv = computeEnvironments[0]
   })
-
+  /*
   it('Initialize compute without transaction IDs', async () => {
     const dataset: ComputeAsset = {
       documentId: publishedComputeDataset.ddo.id,
@@ -297,7 +291,7 @@ describe('Compute', () => {
       getEnvironmentsTask
     )
     computeEnvironments = await streamToObject(response.stream as Readable)
-    firstEnv = computeEnvironments[DEVELOPMENT_CHAIN_ID][0]
+    firstEnv = computeEnvironments[0]
 
     const initializeComputeTask: ComputeInitializeCommand = {
       datasets: [dataset],
@@ -312,12 +306,14 @@ describe('Compute', () => {
     const resp = await new ComputeInitializeHandler(oceanNode).handle(
       initializeComputeTask
     )
+    console.log(resp)
     assert(resp, 'Failed to get response')
     assert(resp.status.httpStatus === 200, 'Failed to get 200 response')
     assert(resp.stream, 'Failed to get stream')
     expect(resp.stream).to.be.instanceOf(Readable)
 
     const result: any = await streamToObject(resp.stream as Readable)
+    console.log(result)
     assert(result.algorithm, 'algorithm does not exist')
     expect(result.algorithm.datatoken?.toLowerCase()).to.be.equal(
       publishedAlgoDataset.datatokenAddress?.toLowerCase()
@@ -579,7 +575,6 @@ describe('Compute', () => {
   it('should start a compute job', async () => {
     // first need to check the existing envs
     // If only FREE envs than start a free compute job instead of a regular/payed one
-    const hasOnlyFreeEnv = computeEnvironments[DEVELOPMENT_CHAIN_ID].length === 1 // && firstEnv.free
 
     const nonce = Date.now().toString()
     const message = String(nonce)
@@ -591,9 +586,7 @@ describe('Compute', () => {
     const messageHashBytes = ethers.toBeArray(consumerMessage)
     const signature = await wallet.signMessage(messageHashBytes)
     const startComputeTask: ComputeStartCommand = {
-      command: hasOnlyFreeEnv
-        ? PROTOCOL_COMMANDS.FREE_COMPUTE_START
-        : PROTOCOL_COMMANDS.COMPUTE_START,
+      command: PROTOCOL_COMMANDS.COMPUTE_START,
       consumerAddress: await wallet.getAddress(),
       signature,
       nonce,
@@ -615,9 +608,7 @@ describe('Compute', () => {
       // additionalDatasets?: ComputeAsset[]
       // output?: ComputeOutput
     }
-    const response = hasOnlyFreeEnv
-      ? await new FreeComputeStartHandler(oceanNode).handle(startComputeTask)
-      : await new ComputeStartHandler(oceanNode).handle(startComputeTask)
+    const response = await new ComputeStartHandler(oceanNode).handle(startComputeTask)
     assert(response, 'Failed to get response')
     assert(response.status.httpStatus === 200, 'Failed to get 200 response')
     assert(response.stream, 'Failed to get stream')
@@ -627,7 +618,7 @@ describe('Compute', () => {
     // eslint-disable-next-line prefer-destructuring
     jobId = jobs[0].jobId
   })
-
+  */
   it('should start a free docker compute job', async () => {
     const nonce = Date.now().toString()
     const message = String(nonce)
@@ -670,32 +661,9 @@ describe('Compute', () => {
     expect(response.stream).to.be.instanceOf(Readable)
 
     const jobs = await streamToObject(response.stream as Readable)
-    // eslint-disable-next-line prefer-destructuring
     assert(jobs[0].jobId, 'failed to got job id')
-  })
-
-  it('should stop a compute job', async () => {
-    const nonce = Date.now().toString()
-    const message = String(nonce)
-    // sign message/nonce
-    const consumerMessage = ethers.solidityPackedKeccak256(
-      ['bytes'],
-      [ethers.hexlify(ethers.toUtf8Bytes(message))]
-    )
-    const messageHashBytes = ethers.toBeArray(consumerMessage)
-    const signature = await wallet.signMessage(messageHashBytes)
-    const stopComputeTask: ComputeStopCommand = {
-      command: PROTOCOL_COMMANDS.COMPUTE_STOP,
-      consumerAddress: await wallet.getAddress(),
-      signature,
-      nonce,
-      jobId
-    }
-    const response = await new ComputeStopHandler(oceanNode).handle(stopComputeTask)
-    assert(response, 'Failed to get response')
-    assert(response.status.httpStatus === 200, 'Failed to get 200 response')
-    assert(response.stream, 'Failed to get stream')
-    expect(response.stream).to.be.instanceOf(Readable)
+    // eslint-disable-next-line prefer-destructuring
+    jobId = jobs[0].jobId
   })
 
   it('should get job status by jobId', async () => {
@@ -733,7 +701,29 @@ describe('Compute', () => {
     const jobs = await streamToObject(response.stream as Readable)
     console.log(jobs)
   })
-
+  it('should stop a compute job', async () => {
+    const nonce = Date.now().toString()
+    const message = String(nonce)
+    // sign message/nonce
+    const consumerMessage = ethers.solidityPackedKeccak256(
+      ['bytes'],
+      [ethers.hexlify(ethers.toUtf8Bytes(message))]
+    )
+    const messageHashBytes = ethers.toBeArray(consumerMessage)
+    const signature = await wallet.signMessage(messageHashBytes)
+    const stopComputeTask: ComputeStopCommand = {
+      command: PROTOCOL_COMMANDS.COMPUTE_STOP,
+      consumerAddress: await wallet.getAddress(),
+      signature,
+      nonce,
+      jobId
+    }
+    const response = await new ComputeStopHandler(oceanNode).handle(stopComputeTask)
+    assert(response, 'Failed to get response')
+    assert(response.status.httpStatus === 200, 'Failed to get 200 response')
+    assert(response.stream, 'Failed to get stream')
+    expect(response.stream).to.be.instanceOf(Readable)
+  })
   it('should deny the Free job due to bad container image (directCommand payload)', async function () {
     freeComputeStartPayload.environment = firstEnv.id
     const command: FreeComputeStartCommand = freeComputeStartPayload
@@ -747,12 +737,6 @@ describe('Compute', () => {
       ),
       'Should have image error'
     )
-  })
-
-  it('should checkC2DEnvExists', async () => {
-    const envId = '0x123'
-    const result = await checkC2DEnvExists(envId, oceanNode)
-    expect(result).to.equal(false)
   })
 
   // algo and checksums related

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -735,6 +735,7 @@ describe('Compute', () => {
   })
 
   it('should deny the Free job due to bad container image (directCommand payload)', async function () {
+    freeComputeStartPayload.environment = firstEnv.id
     const command: FreeComputeStartCommand = freeComputeStartPayload
     const handler = new FreeComputeStartHandler(oceanNode)
     const response = await handler.handle(command)

--- a/src/test/integration/credentials.test.ts
+++ b/src/test/integration/credentials.test.ts
@@ -173,7 +173,7 @@ describe('Should run a complete node flow.', () => {
       const transferTxId = orderTxIds[0]
 
       const wallet = new ethers.Wallet(consumerPrivateKey)
-      const nonce = Math.floor(Date.now() / 1000).toString()
+      const nonce = Date.now().toString()
       const message = String(ddo.id + nonce)
       const consumerMessage = ethers.solidityPackedKeccak256(
         ['bytes'],
@@ -215,7 +215,7 @@ describe('Should run a complete node flow.', () => {
       const transferTxId = orderTxIds[1]
 
       const wallet = new ethers.Wallet(consumerPrivateKey)
-      const nonce = Math.floor(Date.now() / 1000).toString()
+      const nonce = Date.now().toString()
       const message = String(ddo.id + nonce)
       const consumerMessage = ethers.solidityPackedKeccak256(
         ['bytes'],
@@ -256,7 +256,7 @@ describe('Should run a complete node flow.', () => {
       const transferTxId = orderTxIds[1]
 
       const wallet = new ethers.Wallet(consumerPrivateKey)
-      const nonce = Math.floor(Date.now() / 1000).toString()
+      const nonce = Date.now().toString()
       const message = String(ddo.id + nonce)
       const consumerMessage = ethers.solidityPackedKeccak256(
         ['bytes'],

--- a/src/test/integration/download.test.ts
+++ b/src/test/integration/download.test.ts
@@ -240,7 +240,7 @@ describe('Should run a complete node flow.', () => {
       const wallet = new ethers.Wallet(
         '0xef4b441145c1d0f3b4bc6d61d29f5c6e502359481152f869247c7a4244d45209'
       )
-      const nonce = Math.floor(Date.now() / 1000).toString()
+      const nonce = Date.now().toString()
       const message = String(publishedDataset.ddo.id + nonce)
       const consumerMessage = ethers.solidityPackedKeccak256(
         ['bytes'],

--- a/src/test/integration/encryptDecryptDDO.test.ts
+++ b/src/test/integration/encryptDecryptDDO.test.ts
@@ -56,7 +56,7 @@ describe('Should encrypt and decrypt DDO', () => {
   let encryptedMetaData: any
   let documentHash: any
   let indexer: OceanIndexer
-  const nonce = Math.floor(Date.now() / 1000).toString()
+  const nonce = Date.now().toString()
 
   const chainId = 8996
   const mockSupportedNetworks: RPCS = {

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -71,7 +71,7 @@ describe('Compute Jobs Database', () => {
     const dockerConfig = config.c2dClusters[size - 1].connection
     const freeEnv: ComputeEnvironment = dockerConfig.freeComputeOptions
     expect(freeEnv.description).to.be.equal('Free')
-    expect(freeEnv.free).to.be.equal(true)
+    // expect(freeEnv.free).to.be.equal(true)
     expect(freeEnv.id).to.be.equal(config.c2dClusters[size - 1].hash + '-free')
   })
 

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -98,7 +98,9 @@ describe('Compute Jobs Database', () => {
       assets: [dataset],
       isRunning: false,
       isStarted: false,
-      containerImage: 'some container image'
+      containerImage: 'some container image',
+      resources: [],
+      isFree: false
     }
 
     jobId = await db.newJob(job)
@@ -154,7 +156,9 @@ describe('Compute Jobs Database', () => {
       assets: [dataset],
       isRunning: false,
       isStarted: false,
-      containerImage: 'another container image'
+      containerImage: 'another container image',
+      resources: [],
+      isFree: false
     }
 
     const jobId = await db.newJob(job)
@@ -241,6 +245,8 @@ describe('Compute Jobs Database', () => {
     const dockerConfig = config.c2dClusters[size - 1].connection
     const freeEnv: ComputeEnvironment = dockerConfig.freeComputeOptions
     const cpus = os.cpus()
+    /*
+    TODO
     freeEnv.maxCpu = cpus.length + 1 // should be capped to cpus.length
     const docker = new Dockerode({ socketPath: '/var/run/docker.sock' })
     let hostConfig: HostConfig = await buildCPUAndMemoryConstraints(freeEnv, docker)
@@ -250,6 +256,7 @@ describe('Compute Jobs Database', () => {
     expect(hostConfig.CpuCount).to.be.equal(1)
     const ram = os.totalmem()
     expect(hostConfig.Memory).to.be.lessThanOrEqual(ram)
+    */
   })
 
   after(async () => {

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -47,27 +47,14 @@ describe('Compute Jobs Database', () => {
   }
   before(async () => {
     envOverrides = buildEnvOverrideConfig(
-      [ENVIRONMENT_VARIABLES.DOCKER_SOCKET_PATH],
-      ['/var/lib/docker']
+      [ENVIRONMENT_VARIABLES.DOCKER_COMPUTE_ENVIRONMENTS],
+      [
+        '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+      ]
     )
     envOverrides = await setupEnvironment(null, envOverrides)
     config = await getConfiguration(true)
     db = await new C2DDatabase(config.dbConfig, typesenseSchemas.c2dSchemas)
-  })
-
-  it('should have at least a free docker compute environment', () => {
-    let size = 1
-    if (existsEnvironmentVariable(ENVIRONMENT_VARIABLES.OPERATOR_SERVICE_URL, false)) {
-      expect(config.c2dClusters.length).to.be.at.least(2)
-      size = 2
-    } else {
-      expect(config.c2dClusters.length).to.be.at.least(1)
-    }
-    const dockerConfig = config.c2dClusters[size - 1].connection
-    const freeEnv: ComputeEnvironment = dockerConfig.freeComputeOptions
-    expect(freeEnv.description).to.be.equal('Free')
-    // expect(freeEnv.free).to.be.equal(true)
-    expect(freeEnv.id).to.be.equal(config.c2dClusters[size - 1].hash + '-free')
   })
 
   it('should create a new C2D Job', async () => {
@@ -235,24 +222,11 @@ describe('Compute Jobs Database', () => {
     expect(checkManifestPlatform(null, env)).to.be.equal(true)
   })
 
-  it('should check cpu constraints on c2d docker env', async function () {
-    /*
-    TODO
-    const size = config.c2dClusters.length
-    const dockerConfig = config.c2dClusters[size - 1].connection
-    const freeEnv: ComputeEnvironment = dockerConfig.freeComputeOptions
-    const cpus = os.cpus()
-    
-    freeEnv.maxCpu = cpus.length + 1 // should be capped to cpus.length
-    const docker = new Dockerode({ socketPath: '/var/run/docker.sock' })
-    let hostConfig: HostConfig = await buildCPUAndMemoryConstraints(freeEnv, docker)
-    expect(hostConfig.CpuCount).to.be.equal(cpus.length)
-    freeEnv.maxCpu = -1
-    hostConfig = await buildCPUAndMemoryConstraints(freeEnv)
-    expect(hostConfig.CpuCount).to.be.equal(1)
-    const ram = os.totalmem()
-    expect(hostConfig.Memory).to.be.lessThanOrEqual(ram)
-    */
+  it('testing checkAndFillMissingResources', async function () {
+    // TO DO
+  })
+  it('testing checkIfResourcesAreAvailable', async function () {
+    // TO DO
   })
 
   after(async () => {

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -1,12 +1,13 @@
 import { C2DDatabase } from '../../components/database/C2DDatabase.js'
-import { existsEnvironmentVariable, getConfiguration } from '../../utils/config.js'
+// import { existsEnvironmentVariable, getConfiguration } from '../../utils/config.js'
+import { getConfiguration } from '../../utils/config.js'
 import { typesenseSchemas } from '../../components/database/TypesenseSchemas.js'
 import {
   C2DStatusNumber,
   C2DStatusText,
   ComputeAlgorithm,
   ComputeAsset,
-  ComputeEnvironment,
+  // ComputeEnvironment,
   ComputeJob,
   DBComputeJob,
   RunningPlatform

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -29,12 +29,7 @@ import { ENVIRONMENT_VARIABLES } from '../../utils/constants.js'
 import { completeDBComputeJob, dockerImageManifest } from '../data/assets.js'
 import { omitDBComputeFieldsFromComputeJob } from '../../components/c2d/index.js'
 import os from 'os'
-import Dockerode from 'dockerode'
-import {
-  buildCPUAndMemoryConstraints,
-  checkManifestPlatform
-} from '../../components/c2d/compute_engine_docker.js'
-import type { HostConfig } from 'dockerode'
+import { checkManifestPlatform } from '../../components/c2d/compute_engine_docker.js'
 
 describe('Compute Jobs Database', () => {
   let envOverrides: OverrideEnvConfig[]
@@ -241,12 +236,13 @@ describe('Compute Jobs Database', () => {
   })
 
   it('should check cpu constraints on c2d docker env', async function () {
+    /*
+    TODO
     const size = config.c2dClusters.length
     const dockerConfig = config.c2dClusters[size - 1].connection
     const freeEnv: ComputeEnvironment = dockerConfig.freeComputeOptions
     const cpus = os.cpus()
-    /*
-    TODO
+    
     freeEnv.maxCpu = cpus.length + 1 // should be capped to cpus.length
     const docker = new Dockerode({ socketPath: '/var/run/docker.sock' })
     let hostConfig: HostConfig = await buildCPUAndMemoryConstraints(freeEnv, docker)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -407,11 +407,19 @@ function getDockerComputeEnvironments(isStartup?: boolean): C2DDockerConfig[] {
         if (!isDefined(config.fees)) {
           errors += ' There is no fees configuration!'
         }
-        if (!isDefined(config.maxDisk)) {
-          errors += ' There is no maxDisk configuration!'
-        }
+
         if (config.storageExpiry < config.maxJobDuration) {
-          errors += ' "storageExpiry" should be greater than "maxJobDuration"!'
+          errors += ' "storageExpiry" should be greater than "maxJobDuration"! '
+        }
+        // for docker there is no way of getting storage space
+        let foundDisk = false
+        if ('resources' in config) {
+          for (const resource of config.resources) {
+            if (resource.id === 'disk' && resource.total) foundDisk = true
+          }
+        }
+        if (!foundDisk) {
+          errors += ' There is no "disk" resource configured.This is mandatory '
         }
         if (errors.length > 1) {
           CONFIG_LOGGER.error(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,10 +1,6 @@
 import type { DenyList, OceanNodeConfig, OceanNodeKeys } from '../@types/OceanNode'
 import { dhtFilterMethod } from '../@types/OceanNode.js'
-import type {
-  C2DClusterInfo,
-  C2DDockerConfig,
-  ComputeEnvironmentBaseConfig
-} from '../@types/C2D/C2D.js'
+import type { C2DClusterInfo, C2DDockerConfig } from '../@types/C2D/C2D.js'
 import { C2DClusterType } from '../@types/C2D/C2D.js'
 import { createFromPrivKey } from '@libp2p/peer-id-factory'
 import { keys } from '@libp2p/crypto'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -343,11 +343,6 @@ export const ENVIRONMENT_VARIABLES: Record<any, EnvVariable> = {
     value: process.env.DOCKER_COMPUTE_ENVIRONMENTS,
     required: false
   },
-  DOCKER_FREE_COMPUTE: {
-    name: 'DOCKER_FREE_COMPUTE',
-    value: process.env.DOCKER_FREE_COMPUTE,
-    required: false
-  },
   DOCKER_SOCKET_PATH: {
     name: 'DOCKER_SOCKET_PATH',
     value: process.env.DOCKER_SOCKET_PATH,


### PR DESCRIPTION
**_BREAKING CHANGES_**

# Node config #
 We will use DOCKER_COMPUTE_ENVIRONMENTS as a definition of Docker engines & compute envs.
 The full definition is withing interface[ `C2DDockerConfig`](https://github.com/oceanprotocol/ocean-node/blob/feature/docker_refactor/src/%40types/C2D/C2D.ts#L85) 
 
 `free` key is optional, and used to define what resources are available for free within a compute env.

There are no more free and non free compute envs. Just one for each docker engine.

When calling startFreeCompute, node will use resource restrictions from `free` config, if `free` key is defined. if not, startFreeCompute will throw an error.
When calling startCompute, node will use resource restrictions and will ignore `free` config.

This will give us some advantages:
 - easier config
 - resource monitoring
 - at job startup, we can count all used resources and decide if we really have the resources to start the job or not

# Resources #
Every compute env has `resources`.  A resource is defined like:
```json
{
  id: ComputeResourceType
  type?: string
  kind?: string
  total: number // total number of specific resource
  min: number // min number of resource needed for a job
  max: number // max number of resource for a job
  inUse?: number // for display purposes
}
```

There are couple of hardcoded:  `cpu`, `ram` and `disk`, and they can be extended by node owner
Disk resource has to be specified , as for now, there is no safe method of getting the available space.

When starting jobs, user can specify the resources needed, or else, if mins are defined, they are attached automatically

 `Free` resources can be defined for a compute env, this is what anyone can use, for free, using startFreeCompute. They are part of compute env resources, and counted.


## Docker with no free compute ##
```bash
export DOCKER_COMPUTE_ENVIRONMENTS="[{\"socketPath\":\"/var/run/docker.sock\",\"storageExpiry\":604800,\"resources\":[{\"id\":\"disk\",\"total\":1000000000}],\"maxJobDuration\":3600,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]}}]"
```

All other settings are detected automatically, like noOfCpus and RAM:

```
2025-01-23T11:18:01.757Z debug: CORE:   CORE:   ComputeGetEnvironmentsCommand Response: 
[
    {
        "id": "0x6075f99f7962fbd0b122dd62405ee1d09ee6855eaf1095b60c9dbbdc5c76eb05-0xcd0ca6d958fc9f3dbb9a64da37ac638f0d8141319d8679eaf59d53f55a0e487f",
        "runningJobs": 0,
        "consumerAddress": "0xf9C5B7eE7708efAc6dC6Bc7d4b0455eBbf22b519",
        "platform": {
            "architecture": "x86_64",
            "os": "Ubuntu 22.04.3 LTS"
        },
        "fees": {
            "1": [
                [
                    {
                        "feeToken": "0x123",
                        "prices": [
                            {
                                "id": "cpu",
                                "price": 1
                            }
                        ]
                    }
                ]
            ]
        },
        "storageExpiry": 604800,
        "maxJobDuration": 3600,
        "resources": [
            {
                "id": "cpu",
                "total": 16,
                "max": 16,
                "min": 1,
                "inUse": 0
            },
            {
                "id": "ram",
                "total": 33617678336,
                "max": 33617678336,
                "min": 1000000000,
                "inUse": 0
            },
            {
                "id": "disk",
                "total": 1000000000,
                "max": 1000000000,
                "min": 0,
                "inUse": 0
            }
        ],
        "runningfreeJobs": 0
    }
]
```

## Docker with free compute ##
```bash
export  DOCKER_COMPUTE_ENVIRONMENTS="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"disk\",\"total\":1000000000}],\"storageExpiry\":604800,\"maxJobDuration\":3600,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]},\"free\":{\"maxJobDuration\":60,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1000000000},{\"id\":\"disk\",\"max\":1000000000}]}}]"
```


All other settings are detected automatically, like noOfCpus and RAM:

```
2025-01-23T11:19:33.193Z debug: CORE:   CORE:   ComputeGetEnvironmentsCommand Response: 
[
    {
        "id": "0x7d187e4c751367be694497ead35e2937ece3c7f3b325dcb4f7571e5972d092bd-0x3a5647ecc1b6a3b4eaaeaf818037ca5a7aea23b2302f9c09c2ad716d3b0f94c7",
        "runningJobs": 0,
        "consumerAddress": "0xf9C5B7eE7708efAc6dC6Bc7d4b0455eBbf22b519",
        "platform": {
            "architecture": "x86_64",
            "os": "Ubuntu 22.04.3 LTS"
        },
        "fees": {
            "1": [
                [
                    {
                        "feeToken": "0x123",
                        "prices": [
                            {
                                "id": "cpu",
                                "price": 1
                            }
                        ]
                    }
                ]
            ]
        },
        "storageExpiry": 604800,
        "maxJobDuration": 3600,
        "resources": [
            {
                "id": "cpu",
                "total": 16,
                "max": 16,
                "min": 1,
                "inUse": 0
            },
            {
                "id": "ram",
                "total": 33617678336,
                "max": 33617678336,
                "min": 1000000000,
                "inUse": 0
            },
            {
                "id": "disk",
                "total": 1000000000,
                "max": 1000000000,
                "min": 0,
                "inUse": 0
            }
        ],
        "free": {
            "maxJobDuration": 60,
            "maxJobs": 3,
            "resources": [
                {
                    "id": "cpu",
                    "max": 1,
                    "inUse": 0
                },
                {
                    "id": "ram",
                    "max": 1000000000,
                    "inUse": 0
                },
                {
                    "id": "disk",
                    "max": 1000000000,
                    "inUse": 0
                }
            ]
        },
        "runningfreeJobs": 0
    }
]
```


# ComputeEnv interface & getComputeEnvironments command #

 see new structures above

# Commands #

- `startFreeCompute` requires environmentId now
- for `startFreeCompute` and `startCompute` a new optional parameter `resources` is available.   This will allow user to request what resources to use, instead of using all.   Imagine the following scenario:
      - host has 16 cpus and 4 gpus exposed in a compute env
      - in the current setup, if you want to run a job, you will pay for all   (16 x price_per_cpu_per_min + 4 x price_per_gpu)*minutes
      - by using something like `resources: [{ "type":"cpu",amount: 4}, { "type":"gpu",amount: 1}] ` you will only pay for 4 cpus and gpus , because that is what you are going to get
- 
- 