### PR TITLE
fix: return correct message on policy server call

### DIFF
--- a/src/components/policyServer/index.ts
+++ b/src/components/policyServer/index.ts
@@ -24,7 +24,11 @@ export class PolicyServer {
       return { success: true, message: '', httpStatus: 0 }
     }
     if (response.status === 200) {
-      return { success: true, message: '', httpStatus: response.status }
+      return {
+        success: true,
+        message: await response.text(),
+        httpStatus: response.status
+      }
     }
     return { success: false, message: await response.text(), httpStatus: response.status }
   }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add return message if call is 200

need to set the env POLICY_SERVER_URL for example equal to http://ps.oceanenterprise.io:8000/