### PR TITLE
wip: getValidationSignature only for authentificated requests

### DIFF
--- a/src/@types/commands.ts
+++ b/src/@types/commands.ts
@@ -63,6 +63,9 @@ export interface FindDDOCommand extends DDOCommand {
 // https://github.com/oceanprotocol/ocean-node/issues/47
 export interface ValidateDDOCommand extends Command {
   ddo: DDO
+  publisherAddress?: string
+  signature?: string
+  nonce?: string
 }
 
 export interface StatusCommand extends Command {}

--- a/src/test/unit/commands.test.ts
+++ b/src/test/unit/commands.test.ts
@@ -265,7 +265,7 @@ describe('Commands and handlers', () => {
       },
       command: PROTOCOL_COMMANDS.VALIDATE_DDO
     }
-    expect(validateDDOHandler.validate(validateDDOCommand).valid).to.be.equal(true)
+    expect(validateDDOHandler.validate(validateDDOCommand).valid).to.be.equal(false)
     delete validateDDOCommand.ddo
     expect(validateDDOHandler.validate(validateDDOCommand).valid).to.be.equal(false)
     // -----------------------------------------


### PR DESCRIPTION
Fixes #816 

Changes proposed in this PR:

- On `validateDDOCommand` only `getValidationSignature` for authenticated requests
- 
- 