### PR TITLE
Fix validUntil value for free c2d.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,8 @@ jobs:
       - name: Run system tests
         working-directory: ${{ github.workspace }}/ocean-cli
         run: npm run test:system
+        env:
+          AVOID_LOOP_RUN: true
 
   dashboard_build:
     runs-on: ubuntu-latest

--- a/src/@types/commands.ts
+++ b/src/@types/commands.ts
@@ -199,6 +199,7 @@ export interface FreeComputeStartCommand extends Command {
   nonce: string
   environment: string
   algorithm: ComputeAlgorithm
+  validUntil?: number
   datasets?: ComputeAsset[]
   output?: ComputeOutput
   resources?: ComputeResourceRequest[]

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -22,7 +22,7 @@ import { decrypt } from '../../../utils/crypt.js'
 import { verifyProviderFees } from '../utils/feesHandler.js'
 import { Blockchain } from '../../../utils/blockchain.js'
 import { validateOrderTransaction } from '../utils/validateOrders.js'
-import { getConfiguration, validUntil5Mins } from '../../../utils/index.js'
+import { getConfiguration } from '../../../utils/index.js'
 import { sanitizeServiceFiles } from '../../../utils/util.js'
 import { FindDdoHandler } from '../handler/ddoHandler.js'
 import { ProviderFeeValidation } from '../../../@types/Fees.js'
@@ -429,7 +429,7 @@ export class FreeComputeStartHandler extends CommandHandler {
       }
     }
     let engine = null
-    let validUntil = validUntil5Mins
+    let validUntil = null
     try {
       // split compute env (which is already in hash-envId format) and get the hash
       // then get env which might contain dashes as well
@@ -475,29 +475,9 @@ export class FreeComputeStartHandler extends CommandHandler {
         )
         await engine.checkIfResourcesAreAvailable(task.resources, env, true)
         if (task.validUntil) {
-          validUntil = task.validUntil
-          if (env.maxJobDuration && validUntil > env.maxJobDuration) {
-            CORE_LOGGER.logMessage(
-              'FreeComputeStartCommand validUntil bigger than supported max duration job: ' +
-                validUntil +
-                ' fallback to supported max duration job: ' +
-                env.maxJobDuration,
-              true
-            )
-
-            validUntil = env.maxJobDuration
-          }
-        } else {
-          // If task.validUntil is not provided, use 'env.maxJobDuration' if available
-          if (env.maxJobDuration) {
-            CORE_LOGGER.logMessage(
-              'FreeComputeStartCommand validUntil is null,' +
-                ' fallback to supported max duration job: ' +
-                env.maxJobDuration,
-              true
-            )
-            validUntil = env.maxJobDuration
-          }
+          validUntil = env.free.maxJobDuration
+            ? Math.min(task.validUntil, env.free.maxJobDuration)
+            : task.validUntil
         }
       } catch (e) {
         console.error(e)

--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -478,6 +478,8 @@ export class FreeComputeStartHandler extends CommandHandler {
           validUntil = env.free.maxJobDuration
             ? Math.min(task.validUntil, env.free.maxJobDuration)
             : task.validUntil
+        } else {
+          if (env.free.maxJobDuration) validUntil = env.free.maxJobDuration
         }
       } catch (e) {
         console.error(e)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -496,3 +496,5 @@ export const knownUnsafeURLs: string[] = [
   // k8s ETCD
   '^.*(127.0.0.1).*'
 ]
+
+export const validUntil5Mins: number = 300

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -496,5 +496,3 @@ export const knownUnsafeURLs: string[] = [
   // k8s ETCD
   '^.*(127.0.0.1).*'
 ]
-
-export const validUntil5Mins: number = 300


### PR DESCRIPTION
Fixes #900  .

Changes proposed in this PR:

- fix workflow for system tests to avoid infinite loop
- update logic for `validUntil`:
 If validUntil exceeds env.maxJobDuration -> `validUntil == env.maxJobDuration`
- if validUntil is not provided (because it was set with null on free start compute task) -> fallback to `env.maxJobDuration` if exists, if `env.maxJobDuration` does not exist -> validUntil remains null.