### PR TITLE
Fix CPU quota computation used in docker

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -688,7 +688,7 @@ export class C2DEngineDocker extends C2DEngine {
       if (cpus && cpus > 0) {
         const systemInfo = this.docker ? await this.docker.info() : null
         hostConfig.CpuPeriod = 100000 // 100 miliseconds is usually the default
-        hostConfig.CpuQuota = (cpus / systemInfo.NCPU) * hostConfig.CpuPeriod
+        hostConfig.CpuQuota = Math.floor((cpus / systemInfo.NCPU) * hostConfig.CpuPeriod)
       }
       const containerInfo: ContainerCreateOptions = {
         name: job.jobId + '-algoritm',


### PR DESCRIPTION
Fixes #907 

Changes proposed in this PR:
- Floor the result of cpu quota computation and fix `cannot unmarshal number 8333.333333333332 into Go struct field HostConfig.HostConfig.CpuQuota of type int64 `