### PR TITLE
Fix/ Use safe headers for Arweave storage type

### DIFF
--- a/src/components/core/handler/downloadHandler.ts
+++ b/src/components/core/handler/downloadHandler.ts
@@ -234,7 +234,7 @@ export class DownloadHandler extends CommandHandler {
     const ddo = await handler.findAndFormatDdo(task.documentId)
 
     if (ddo) {
-      CORE_LOGGER.logMessage('DDO for asset found: ' + ddo, true)
+      CORE_LOGGER.logMessage('DDO for asset found: ' + JSON.stringify(ddo), true)
     } else {
       CORE_LOGGER.logMessage(
         'No DDO for asset found. Cannot proceed with download.',

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -227,7 +227,13 @@ providerRoutes.get(
 
       if (response.stream) {
         res.status(response.status.httpStatus)
-        res.set(response.status.headers)
+
+        const safeHeaders = { ...response.status.headers }
+        if (safeHeaders['content-length'] && safeHeaders['Transfer-Encoding']) {
+          delete safeHeaders['content-length']
+        }
+
+        res.set(safeHeaders)
         response.stream.pipe(res)
       } else {
         res.status(response.status.httpStatus).send(response.status.error)

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -238,7 +238,7 @@ providerRoutes.get(
         }
 
         res.set(safeHeaders)
-        HTTP_LOGGER.logMessage(`Headers: ${JSON.stringify(safeHeaders)}`, true)
+        HTTP_LOGGER.logMessage(`Sanitized Headers: ${JSON.stringify(safeHeaders)}`, true)
         response.stream.pipe(res)
       } else {
         res.status(response.status.httpStatus).send(response.status.error)

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -227,6 +227,10 @@ providerRoutes.get(
 
       if (response.stream) {
         res.status(response.status.httpStatus)
+        HTTP_LOGGER.logMessage(
+          `Headers: ${JSON.stringify(response.status.headers)}`,
+          true
+        )
 
         const safeHeaders = { ...response.status.headers }
         if (safeHeaders['content-length'] && safeHeaders['Transfer-Encoding']) {
@@ -234,6 +238,7 @@ providerRoutes.get(
         }
 
         res.set(safeHeaders)
+        HTTP_LOGGER.logMessage(`Headers: ${JSON.stringify(safeHeaders)}`, true)
         response.stream.pipe(res)
       } else {
         res.status(response.status.httpStatus).send(response.status.error)

--- a/src/components/httpRoutes/provider.ts
+++ b/src/components/httpRoutes/provider.ts
@@ -227,10 +227,6 @@ providerRoutes.get(
 
       if (response.stream) {
         res.status(response.status.httpStatus)
-        HTTP_LOGGER.logMessage(
-          `Headers: ${JSON.stringify(response.status.headers)}`,
-          true
-        )
 
         const safeHeaders = { ...response.status.headers }
         if (safeHeaders['content-length'] && safeHeaders['Transfer-Encoding']) {
@@ -238,7 +234,6 @@ providerRoutes.get(
         }
 
         res.set(safeHeaders)
-        HTTP_LOGGER.logMessage(`Sanitized Headers: ${JSON.stringify(safeHeaders)}`, true)
         response.stream.pipe(res)
       } else {
         res.status(response.status.httpStatus).send(response.status.error)

--- a/src/components/storage/index.ts
+++ b/src/components/storage/index.ts
@@ -63,8 +63,6 @@ export abstract class Storage {
     config: OceanNodeConfig
   ): UrlStorage | IpfsStorage | ArweaveStorage {
     const { type } = file
-    console.log('Storage type:', type)
-    console.log('Storage file:', file)
     switch (
       type?.toLowerCase() // case insensitive
     ) {

--- a/src/components/storage/index.ts
+++ b/src/components/storage/index.ts
@@ -63,6 +63,8 @@ export abstract class Storage {
     config: OceanNodeConfig
   ): UrlStorage | IpfsStorage | ArweaveStorage {
     const { type } = file
+    console.log('Storage type:', type)
+    console.log('Storage file:', file)
     switch (
       type?.toLowerCase() // case insensitive
     ) {


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- delete 'content-length' header if 'Transfer-Encoding' header is set since having both present at same time is not allowed by the http protocol