### PR TITLE
chore: return schema

### DIFF
--- a/src/components/database/ElasticSearchDatabase.ts
+++ b/src/components/database/ElasticSearchDatabase.ts
@@ -472,10 +472,11 @@ export class ElasticsearchDdoDatabase extends AbstractDdoDatabase {
   }
 
   getDDOSchema(ddo: Record<string, any>) {
-    const ddoInstance = DDOManager.getDDOClass(ddo)
-    const { nft } = ddoInstance.getDDOFields() as any
     let schemaName: string | undefined
-    if (nft?.state !== 0) {
+    const ddoInstance = DDOManager.getDDOClass(ddo)
+    const ddoData = ddoInstance.getDDOData()
+
+    if ('indexedMetadata' in ddoData && ddoData?.indexedMetadata?.nft.state !== 0) {
       schemaName = 'op_ddo_short'
     } else if (ddo.version) {
       schemaName = `op_ddo_v${ddo.version}`
@@ -492,8 +493,8 @@ export class ElasticsearchDdoDatabase extends AbstractDdoDatabase {
 
   async validateDDO(ddo: Record<string, any>): Promise<boolean> {
     const ddoInstance = DDOManager.getDDOClass(ddo)
-    const { nft } = ddoInstance.getDDOFields() as any
-    if ('indexedMetadata' in ddoInstance.getDDOData() && nft?.state !== 0) {
+    const ddoData = ddoInstance.getDDOData()
+    if ('indexedMetadata' in ddoData && ddoData.indexedMetadata?.nft?.state !== 0) {
       // Skipping validation for short DDOs as it currently doesn't work
       // TODO: DDO validation needs to be updated to consider the fields required by the schema
       // See github issue: https://github.com/oceanprotocol/ocean-node/issues/256


### PR DESCRIPTION
Issue:
nft is not in ddoInstance.getDDOFields() becouse now is in indexedMetadata, now the schema is always op_short so the indexer will store into that index instead of the index op_ddo_v${ddo.version}

Fixes # .

Changes proposed in this PR:

- getting nft from ddoInstance.getDDOData().indexedMetadata
- returning correct schema
- indexer store in correct index
