### PR TITLE
fix: policy server from body

### DIFF
--- a/src/components/core/compute/startCompute.ts
+++ b/src/components/core/compute/startCompute.ts
@@ -170,7 +170,6 @@ export class PaidComputeStartHandler extends CommandHandler {
           const ddoInstance = DDOManager.getDDOClass(ddo)
           const {
             chainId: ddoChainId,
-            services,
             metadata,
             nftAddress,
             credentials
@@ -335,11 +334,15 @@ export class PaidComputeStartHandler extends CommandHandler {
             }
           }
           if (metadata.type !== 'algorithm') {
+            const index = task.datasets.findIndex(
+              (d) => d.documentId === ddoInstance.getDid()
+            )
+            const safeIndex = index === -1 ? 0 : index
             const validAlgoForDataset = await validateAlgoForDataset(
               task.algorithm.documentId,
               algoChecksums,
               ddoInstance,
-              services[0].id,
+              task.datasets[safeIndex].serviceId,
               node
             )
             if (!validAlgoForDataset) {

--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -78,7 +78,7 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/compute`, async (req, res) => {
       datasets: (req.body.datasets as unknown as ComputeAsset[]) || null,
       payment: (req.body.payment as unknown as ComputePayment) || null,
       resources: (req.body.resources as unknown as ComputeResourceRequest[]) || null,
-      policyServer: (req.query.policyServer as PolicyServerTask) || null,
+      policyServer: (req.body.policyServer as PolicyServerTask) || null,
       metadata: req.body.metadata || null,
       authorization: req.headers?.authorization
     }
@@ -122,7 +122,7 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/freeCompute`, async (req, res) => 
       datasets: (req.body.datasets as unknown as ComputeAsset[]) || null,
       resources: (req.body.resources as unknown as ComputeResourceRequest[]) || null,
       maxJobDuration: req.body.maxJobDuration || null,
-      policyServer: (req.query.policyServer as PolicyServerTask) || null,
+      policyServer: (req.body.policyServer as PolicyServerTask) || null,
       metadata: req.body.metadata || null,
       authorization: req.headers?.authorization
     }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- policyServer object comes from ocean js as req.body not from req.query
- correct service on validateAlgoForDataset