### PR TITLE
Fix rate limiter on number of requests & connections

### DIFF
--- a/src/components/Auth/index.ts
+++ b/src/components/Auth/index.ts
@@ -3,11 +3,7 @@ import jwt from 'jsonwebtoken'
 import { checkNonce, NonceResponse } from '../core/utils/nonceHandler.js'
 import { OceanNode } from '../../OceanNode.js'
 import { getConfiguration } from '../../utils/index.js'
-
-export interface CommonValidation {
-  valid: boolean
-  error: string
-}
+import { CommonValidation } from '../../utils/validators.js'
 
 export interface AuthValidation {
   token?: string

--- a/src/components/P2P/handleProtocolCommands.ts
+++ b/src/components/P2P/handleProtocolCommands.ts
@@ -9,16 +9,10 @@ import { GENERIC_EMOJIS, LOG_LEVELS_STR } from '../../utils/logging/Logger.js'
 import StreamConcat from 'stream-concat'
 import { BaseHandler } from '../core/handler/handler.js'
 import { getConfiguration } from '../../utils/index.js'
-import { checkConnectionsRateLimit } from '../httpRoutes/requestValidator.js'
-import { CONNECTIONS_RATE_INTERVAL } from '../../utils/constants.js'
-import { RequestLimiter } from '../../OceanNode.js'
-
-// hold data about last request made
-const connectionsData: RequestLimiter = {
-  lastRequestTime: Date.now(),
-  requester: '',
-  numRequests: 0
-}
+import {
+  checkGlobalConnectionsRateLimit,
+  checkRequestsRateLimit
+} from '../../utils/validators.js'
 
 export class ReadableString extends Readable {
   private sent = false
@@ -94,22 +88,32 @@ export async function handleProtocolCommands(otherPeerConnection: any) {
     }
   }
   // check connections rate limit
-  const requestTime = Date.now()
-  if (requestTime - connectionsData.lastRequestTime > CONNECTIONS_RATE_INTERVAL) {
-    // last one was more than 1 minute ago? reset counter
-    connectionsData.numRequests = 0
-  }
-  // always increment counter
-  connectionsData.numRequests += 1
-  // update time and requester information
-  connectionsData.lastRequestTime = requestTime
-  connectionsData.requester = remoteAddr
+  const now = Date.now()
 
-  // check global rate limits (not ip related)
-  const requestRateValidation = checkConnectionsRateLimit(configuration, connectionsData)
-  if (!requestRateValidation.valid) {
+  const rateLimitCheck = checkRequestsRateLimit(remoteAddr, configuration, now)
+  if (!rateLimitCheck.valid) {
     P2P_LOGGER.warn(
       `Incoming request denied to peer: ${remotePeer} (rate limit exceeded)`
+    )
+    if (connectionStatus === 'open') {
+      statusStream = new ReadableString(
+        JSON.stringify(buildWrongCommandStatus(403, 'Rate limit exceeded'))
+      )
+      try {
+        await pipe(statusStream, otherPeerConnection.stream.sink)
+      } catch (e) {
+        P2P_LOGGER.error(e)
+      }
+    }
+    await closeStreamConnection(otherPeerConnection.connection, remotePeer)
+    return
+  }
+
+  // check global rate limits (not ip related)
+  const connectionsRateValidation = checkGlobalConnectionsRateLimit(configuration, now)
+  if (!connectionsRateValidation.valid) {
+    P2P_LOGGER.warn(
+      `Exceeded limit of connections per minute ${configuration.maxConnections}: ${connectionsRateValidation.error}`
     )
     if (connectionStatus === 'open') {
       statusStream = new ReadableString(

--- a/src/components/core/admin/adminHandler.ts
+++ b/src/components/core/admin/adminHandler.ts
@@ -8,9 +8,9 @@ import {
 } from '../../httpRoutes/validateCommands.js'
 import { validateAdminSignature } from '../../../utils/auth.js'
 import { BaseHandler } from '../handler/handler.js'
-import { CommonValidation } from '../../httpRoutes/requestValidator.js'
 import { P2PCommandResponse } from '../../../@types/OceanNode.js'
 import { ReadableString } from '../../P2P/handleProtocolCommands.js'
+import { CommonValidation } from '../../../utils/validators.js'
 
 export abstract class AdminCommandHandler
   extends BaseHandler

--- a/src/components/httpRoutes/logs.ts
+++ b/src/components/httpRoutes/logs.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import { validateAdminSignature } from '../../utils/auth.js'
 import { HTTP_LOGGER } from '../../utils/logging/common.js'
-import { CommonValidation } from './requestValidator.js'
+import { CommonValidation } from '../../utils/validators.js'
 
 export const logRoutes = express.Router()
 

--- a/src/components/httpRoutes/requestValidator.ts
+++ b/src/components/httpRoutes/requestValidator.ts
@@ -2,24 +2,15 @@ import { Request, Response } from 'express'
 import { getConfiguration } from '../../utils/config.js'
 import { HTTP_LOGGER } from '../../utils/logging/common.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
-import { RequestLimiter } from '../../OceanNode.js'
 import {
-  CONNECTIONS_RATE_INTERVAL,
-  DEFAULT_MAX_CONNECTIONS_PER_MINUTE
-} from '../../utils/constants.js'
-
-// TODO we should group common stuff,
-// we have multiple similar validation interfaces
-export interface CommonValidation {
-  valid: boolean
-  error?: string
-}
-
-// hold data about last request made
-const connectionsData = new Map<string, RequestLimiter>()
+  checkGlobalConnectionsRateLimit,
+  checkRequestsRateLimit,
+  CommonValidation
+} from '../../utils/validators.js'
 
 // Middleware to validate IP and apply rate limiting
 export const requestValidator = async function (req: Request, res: Response, next: any) {
+  const now = Date.now()
   const requestIP = (req.headers['x-forwarded-for'] ||
     req.socket.remoteAddress ||
     '') as string
@@ -32,7 +23,7 @@ export const requestValidator = async function (req: Request, res: Response, nex
     return res.status(403).send(ipValidation.error)
   }
 
-  const rateLimitCheck = checkRequestsRateLimit(requestIP, configuration)
+  const rateLimitCheck = checkRequestsRateLimit(requestIP, configuration, now)
   if (!rateLimitCheck.valid) {
     HTTP_LOGGER.logMessage(
       `Exceeded limit of requests per minute ${configuration.rateLimit}: ${rateLimitCheck.error}`
@@ -40,71 +31,13 @@ export const requestValidator = async function (req: Request, res: Response, nex
     return res.status(429).send(rateLimitCheck.error)
   }
 
-  const requestRateValidation = checkConnectionsRateLimit(
-    configuration,
-    connectionsData.get(requestIP)
-  )
-  if (!requestRateValidation.valid) {
-    HTTP_LOGGER.logMessage(
-      `Exceeded limit of connections per minute ${configuration.maxConnections}: ${requestRateValidation.error}`
-    )
-    res.status(403).send(requestRateValidation.error)
+  const connectionsRateValidation = checkGlobalConnectionsRateLimit(configuration, now)
+  if (!connectionsRateValidation.valid) {
+    res.status(403).send(connectionsRateValidation.error)
     return
   }
 
   next()
-}
-
-function checkRequestsRateLimit(
-  requestIP: string,
-  configuration: OceanNodeConfig
-): CommonValidation {
-  const requestTime = Date.now()
-  const limit = configuration.rateLimit
-  let clientData = connectionsData.get(requestIP)
-
-  if (!clientData || clientData === undefined) {
-    clientData = {
-      lastRequestTime: requestTime,
-      requester: requestIP,
-      numRequests: 1
-    }
-    connectionsData.set(requestIP, clientData)
-    return { valid: true, error: '' }
-  }
-
-  const timeSinceLastRequest = requestTime - clientData.lastRequestTime
-  const windowExpired = timeSinceLastRequest > CONNECTIONS_RATE_INTERVAL
-
-  if (clientData.numRequests >= limit && !windowExpired) {
-    const waitTime = Math.ceil((CONNECTIONS_RATE_INTERVAL - timeSinceLastRequest) / 1000)
-    return {
-      valid: false,
-      error: `Rate limit exceeded. Try again in ${waitTime} seconds.`
-    }
-  }
-
-  if (windowExpired) {
-    clientData.numRequests = 1
-    clientData.lastRequestTime = requestTime
-    return { valid: true, error: '' }
-  }
-
-  clientData.numRequests += 1
-  return { valid: true, error: '' }
-}
-
-export function checkConnectionsRateLimit(
-  configuration: OceanNodeConfig,
-  connectionsData: RequestLimiter
-): CommonValidation {
-  const connectionLimits =
-    configuration.maxConnections || DEFAULT_MAX_CONNECTIONS_PER_MINUTE
-  const ok = connectionsData.numRequests <= connectionLimits
-  return {
-    valid: ok,
-    error: ok ? '' : 'Unauthorized request. Rate limit exceeded!'
-  }
 }
 
 function checkIP(

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -7,7 +7,7 @@ import AccessListContract from '@oceanprotocol/contracts/artifacts/contracts/acc
 import { getAccountsFromAccessList } from '../utils/credentials.js'
 import { OceanNodeConfig } from '../@types/OceanNode.js'
 import { LOG_LEVELS_STR } from './logging/Logger.js'
-import { CommonValidation } from '../components/httpRoutes/requestValidator.js'
+import { CommonValidation } from './validators.js'
 export async function validateAdminSignature(
   expiryTimestamp: number,
   signature: string

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,6 +1,22 @@
 import { ConsumerParameter } from '../@types/DDO/ConsumerParameter.js'
+import { OceanNodeConfig } from '../@types/OceanNode.js'
 import { ValidateParams } from '../components/httpRoutes/validateCommands.js'
+import { RequestLimiter } from '../OceanNode.js'
 import { CORE_LOGGER } from './logging/common.js'
+import {
+  CONNECTIONS_RATE_INTERVAL,
+  DEFAULT_MAX_CONNECTIONS_PER_MINUTE
+} from './constants.js'
+
+// TODO we should group common stuff,
+// we have multiple similar validation interfaces
+export interface CommonValidation {
+  valid: boolean
+  error?: string
+}
+
+// hold data about last request made
+const connectionsData = new Map<string, RequestLimiter>()
 
 function checkString(value: any) {
   return typeof value === 'string' || value instanceof String
@@ -16,6 +32,68 @@ function checkNumber(value: any) {
 
 function checkObject(value: any) {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function checkRequestsRateLimit(
+  requestIP: string,
+  configuration: OceanNodeConfig,
+  now: number
+): CommonValidation {
+  const limit = configuration.rateLimit
+  let clientData = connectionsData.get(requestIP)
+
+  if (!clientData || clientData === undefined) {
+    clientData = {
+      lastRequestTime: now,
+      requester: requestIP,
+      numRequests: 1
+    }
+    connectionsData.set(requestIP, clientData)
+    return { valid: true, error: '' }
+  }
+
+  const timeSinceLastRequest = now - clientData.lastRequestTime
+  const windowExpired = timeSinceLastRequest > CONNECTIONS_RATE_INTERVAL
+
+  if (clientData.numRequests >= limit && !windowExpired) {
+    const waitTime = Math.ceil((CONNECTIONS_RATE_INTERVAL - timeSinceLastRequest) / 1000)
+    return {
+      valid: false,
+      error: `Rate limit exceeded. Try again in ${waitTime} seconds.`
+    }
+  }
+
+  if (windowExpired) {
+    clientData.numRequests = 1
+    clientData.lastRequestTime = now
+    return { valid: true, error: '' }
+  }
+
+  clientData.numRequests += 1
+  return { valid: true, error: '' }
+}
+
+export function checkGlobalConnectionsRateLimit(
+  configuration: OceanNodeConfig,
+  now: number
+): CommonValidation {
+  const maxConnections =
+    configuration.maxConnections || DEFAULT_MAX_CONNECTIONS_PER_MINUTE
+  let activeRequesters = 0
+
+  for (const [, clientData] of connectionsData.entries()) {
+    if (now - clientData.lastRequestTime <= CONNECTIONS_RATE_INTERVAL) {
+      activeRequesters += 1
+    }
+  }
+  const valid = activeRequesters <= maxConnections
+
+  return {
+    valid,
+    error: valid
+      ? ''
+      : `Too many active connections (${activeRequesters}/${maxConnections}) in the last minute.`
+  }
 }
 
 export function validateConsumerParameters(


### PR DESCRIPTION
Fixes #981  .

Changes proposed in this PR:

- implement logic regarding rate limiter for no. of requests per minute
- implement logic regarding rate limiter for no. of global connections per minute 
- integrate for HTTP and P2P protocols
- keep only one interface of CommonValidation