### PR TITLE
fix stopCompute docker

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -450,7 +450,19 @@ export class C2DEngineDocker extends C2DEngine {
     owner: string,
     agreementId?: string
   ): Promise<ComputeJob[]> {
-    return null
+    const jobs = await this.db.getJob(jobId, agreementId, owner)
+    if (jobs.length === 0) {
+      return []
+    }
+    const statusResults = []
+    for (const job of jobs) {
+      job.stopRequested = true
+      await this.db.updateJob(job)
+      const res: ComputeJob = omitDBComputeFieldsFromComputeJob(job)
+      statusResults.push(res)
+    }
+
+    return statusResults
   }
 
   // eslint-disable-next-line require-await

--- a/src/components/c2d/index.ts
+++ b/src/components/c2d/index.ts
@@ -35,7 +35,6 @@ export function omitDBComputeFieldsFromComputeJob(dbCompute: DBComputeJob): Comp
     'publishlogURL',
     'algologURL',
     'outputsURL',
-    'stopRequested',
     'algorithm',
     'assets',
     'isRunning',

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -209,9 +209,6 @@ describe('Compute Jobs Database', () => {
     )
     expect(Object.prototype.hasOwnProperty.call(output, 'algologURL')).to.be.equal(false)
     expect(Object.prototype.hasOwnProperty.call(output, 'outputsURL')).to.be.equal(false)
-    expect(Object.prototype.hasOwnProperty.call(output, 'stopRequested')).to.be.equal(
-      false
-    )
     expect(Object.prototype.hasOwnProperty.call(output, 'algorithm')).to.be.equal(false)
     expect(Object.prototype.hasOwnProperty.call(output, 'assets')).to.be.equal(false)
     expect(Object.prototype.hasOwnProperty.call(output, 'isRunning')).to.be.equal(false)


### PR DESCRIPTION
Fixes #992

Changes proposed in this PR:

- add stopCompute logic

The stop logic is already handled in https://github.com/oceanprotocol/ocean-node/blob/main/src/components/c2d/compute_engine_docker.ts#L915