### PR TITLE
Cleanup unit tests. Replace Database constructor with async init fn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,10 @@ let node: OceanP2P = null
 let indexer = null
 let provider = null
 // If there is no DB URL only the nonce database will be available
-const dbconn: Database = await new Database(config.dbConfig)
+const dbconn: Database = await Database.init(config.dbConfig)
+if (!dbconn) {
+  OCEAN_NODE_LOGGER.error('Database failed to initialize')
+}
 
 if (!hasValidDBConfiguration(config.dbConfig)) {
   // once we create a database instance, we check the environment and possibly add the DB transport

--- a/src/test/integration/algorithmsAccess.test.ts
+++ b/src/test/integration/algorithmsAccess.test.ts
@@ -108,7 +108,7 @@ describe('Trusted algorithms Flow', () => {
       )
     )
     config = await getConfiguration(true)
-    dbconn = await new Database(config.dbConfig)
+    dbconn = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, dbconn, null, null, null)
     indexer = new OceanIndexer(dbconn, config.indexingNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/auth.test.ts
+++ b/src/test/integration/auth.test.ts
@@ -47,7 +47,7 @@ describe('Auth Token Integration Tests', () => {
     )
 
     config = await getConfiguration(true)
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, database)
 
     provider = new JsonRpcProvider(mockSupportedNetworks['8996'].rpc)

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -145,7 +145,7 @@ describe('Compute', () => {
       )
     )
     config = await getConfiguration(true)
-    dbconn = await new Database(config.dbConfig)
+    dbconn = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, dbconn, null, null, null, true)
     indexer = new OceanIndexer(dbconn, config.indexingNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/configDatabase.test.ts
+++ b/src/test/integration/configDatabase.test.ts
@@ -22,7 +22,7 @@ describe('Config Database', () => {
   let initialVersionNull: any
 
   before(async () => {
-    database = await new Database(versionConfig)
+    database = await Database.init(versionConfig)
 
     it('should have null version initially', async () => {
       initialVersionNull = await oceanIndexer.getDatabase().sqliteConfig.retrieveValue()
@@ -75,7 +75,7 @@ describe('VersionDatabase CRUD (without Elastic or Typesense config)', () => {
   let database: Database
 
   before(async () => {
-    database = await new Database(emptyDBConfig)
+    database = await Database.init(emptyDBConfig)
   })
 
   it('check version DB instance of SQL Lite', () => {

--- a/src/test/integration/credentials.test.ts
+++ b/src/test/integration/credentials.test.ts
@@ -135,7 +135,7 @@ describe('[Credentials Flow] - Should run a complete node flow.', () => {
     )
 
     config = await getConfiguration(true) // Force reload the configuration
-    const database = await new Database(config.dbConfig)
+    const database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, database)
     const indexer = new OceanIndexer(database, config.indexingNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/database.test.ts
+++ b/src/test/integration/database.test.ts
@@ -27,7 +27,7 @@ describe('Database', () => {
   let database: Database
 
   before(async () => {
-    database = await new Database(typesenseConfig)
+    database = await Database.init(typesenseConfig)
   })
 
   it('instance Database', () => {
@@ -62,7 +62,7 @@ describe('DdoDatabase CRUD', () => {
   }
 
   before(async () => {
-    database = await new Database(typesenseConfig)
+    database = await Database.init(typesenseConfig)
   })
 
   it('creates ddo schema as an array', () => {
@@ -89,7 +89,7 @@ describe('NonceDatabase CRUD - SQL lite (With typesense DB config)', () => {
   let database: Database
 
   before(async () => {
-    database = await new Database(typesenseConfig)
+    database = await Database.init(typesenseConfig)
   })
 
   it('check nonce DB instance of SQL Lite', () => {
@@ -125,7 +125,7 @@ describe('NonceDatabase CRUD (without Elastic or Typesense config)', () => {
   let database: Database
 
   before(async () => {
-    database = await new Database(emptyDBConfig)
+    database = await Database.init(emptyDBConfig)
   })
 
   it('check nonce DB instance of SQL Lite', () => {
@@ -162,7 +162,7 @@ describe('IndexerDatabase CRUD', () => {
   let existsPrevious: any = {}
 
   before(async () => {
-    database = await new Database(typesenseConfig)
+    database = await Database.init(typesenseConfig)
   })
 
   it('create indexer', async () => {
@@ -205,7 +205,7 @@ describe('OrderDatabase CRUD', () => {
   let database: Database
 
   before(async () => {
-    database = await new Database(typesenseConfig)
+    database = await Database.init(typesenseConfig)
   })
 
   it('create order', async () => {

--- a/src/test/integration/download.test.ts
+++ b/src/test/integration/download.test.ts
@@ -88,7 +88,7 @@ describe('[Download Flow] - Should run a complete node flow.', () => {
     )
 
     config = await getConfiguration(true) // Force reload the configuration
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, database)
     indexer = new OceanIndexer(database, config.indexingNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/elasticsearch.test.ts
+++ b/src/test/integration/elasticsearch.test.ts
@@ -15,7 +15,7 @@ const dbConfig = {
   url: 'http://localhost:9200',
   dbType: DB_TYPES.ELASTIC_SEARCH
 }
-const elasticsearch: Database = await new Database(dbConfig)
+const elasticsearch: Database = await Database.init(dbConfig)
 
 describe('Elastic Search', () => {
   it('Get instances of Elastic Search', () => {

--- a/src/test/integration/encryptDecryptDDO.test.ts
+++ b/src/test/integration/encryptDecryptDDO.test.ts
@@ -104,7 +104,7 @@ describe('Should encrypt and decrypt DDO', () => {
       publisherAccount
     )
     const config = await getConfiguration()
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = OceanNode.getInstance(config, database)
     // will be used later
     indexer = new OceanIndexer(database, mockSupportedNetworks)

--- a/src/test/integration/encryptFile.test.ts
+++ b/src/test/integration/encryptFile.test.ts
@@ -31,7 +31,7 @@ describe('Encrypt File', () => {
       )
     )
     config = await getConfiguration(true) // Force reload the configuration
-    const dbconn = await new Database(config.dbConfig)
+    const dbconn = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, dbconn)
   })
 

--- a/src/test/integration/indexer.test.ts
+++ b/src/test/integration/indexer.test.ts
@@ -110,7 +110,7 @@ describe('Indexer stores a new metadata events and orders.', () => {
     )
 
     const config = await getConfiguration(true)
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, database)
     indexer = new OceanIndexer(database, mockSupportedNetworks)
     oceanNode.addIndexer(indexer)
@@ -692,7 +692,7 @@ describe('OceanIndexer - crawler threads', () => {
     )
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
-    db = await new Database(config.dbConfig)
+    db = await Database.init(config.dbConfig)
   })
 
   it('should start a worker thread and handle RPCS "startBlock"', async () => {

--- a/src/test/integration/logs.test.ts
+++ b/src/test/integration/logs.test.ts
@@ -37,7 +37,7 @@ describe('LogDatabase CRUD', () => {
       buildEnvOverrideConfig([ENVIRONMENT_VARIABLES.LOG_DB], ['true'])
     )
     const { dbConfig } = await getConfiguration(true)
-    database = await new Database(dbConfig)
+    database = await Database.init(dbConfig)
     // Initialize logger with the custom transport that writes to the LogDatabase
     logger = getCustomLoggerForModule(
       LOGGER_MODULE_NAMES.HTTP,
@@ -179,7 +179,7 @@ describe('LogDatabase retrieveMultipleLogs with specific parameters', () => {
     )
 
     const { dbConfig } = await getConfiguration(true)
-    database = await new Database(dbConfig)
+    database = await Database.init(dbConfig)
   })
 
   it('should retrieve logs with a specific moduleName', async () => {
@@ -245,7 +245,7 @@ describe('LogDatabase retrieveMultipleLogs with specific parameters', () => {
 
     before(async () => {
       const { dbConfig } = await getConfiguration(true)
-      database = await new Database(dbConfig)
+      database = await Database.init(dbConfig)
     })
 
     it('should insert a log for deletion', async () => {
@@ -348,7 +348,7 @@ describe('LogDatabase deleteOldLogs', () => {
       buildEnvOverrideConfig([ENVIRONMENT_VARIABLES.LOG_DB], ['true'])
     )
     const { dbConfig } = await getConfiguration(true)
-    database = await new Database(dbConfig)
+    database = await Database.init(dbConfig)
   })
 
   it('should insert an old log and a recent log', async () => {
@@ -413,7 +413,7 @@ describe('LogDatabase retrieveMultipleLogs with pagination', () => {
       buildEnvOverrideConfig([ENVIRONMENT_VARIABLES.LOG_DB], ['true'])
     )
     const { dbConfig } = await getConfiguration(true)
-    database = await new Database(dbConfig)
+    database = await Database.init(dbConfig)
 
     // Insert multiple log entries to ensure there are enough logs for pagination
     for (let i = 0; i < logCount; i++) {

--- a/src/test/integration/operationsDashboard.test.ts
+++ b/src/test/integration/operationsDashboard.test.ts
@@ -105,7 +105,7 @@ describe('Should test admin operations', () => {
     )
 
     config = await getConfiguration(true) // Force reload the configuration
-    dbconn = await new Database(config.dbConfig)
+    dbconn = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, dbconn)
     indexer = new OceanIndexer(dbconn, config.indexingNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/pricing.test.ts
+++ b/src/test/integration/pricing.test.ts
@@ -84,7 +84,7 @@ describe('Publish pricing scehmas and assert ddo stats - FRE & Dispenser', () =>
     )
 
     const config = await getConfiguration(true)
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance()
     indexer = new OceanIndexer(database, mockSupportedNetworks)
     oceanNode.addIndexer(indexer)

--- a/src/test/integration/transactionValidation.test.ts
+++ b/src/test/integration/transactionValidation.test.ts
@@ -67,7 +67,7 @@ describe('validateOrderTransaction Function with Orders', () => {
     )
 
     config = await getConfiguration(true) // Force reload the configuration
-    const dbconn = await new Database(config.dbConfig)
+    const dbconn = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(config, dbconn)
     indexer = new OceanIndexer(dbconn, config.indexingNetworks)
     oceanNode.addIndexer(indexer)
@@ -89,7 +89,7 @@ describe('validateOrderTransaction Function with Orders', () => {
     }
 
     const { dbConfig } = await getConfiguration(true)
-    database = await new Database(dbConfig)
+    database = await Database.init(dbConfig)
   })
 
   it('Start instance of Database', () => {

--- a/src/test/unit/blockchain.test.ts
+++ b/src/test/unit/blockchain.test.ts
@@ -7,6 +7,7 @@ import { ENVIRONMENT_VARIABLES } from '../../utils/constants.js'
 import {
   DEFAULT_TEST_TIMEOUT,
   OverrideEnvConfig,
+  TEST_ENV_CONFIG_FILE,
   buildEnvOverrideConfig,
   setupEnvironment,
   tearDownEnvironment
@@ -28,7 +29,7 @@ describe('Should validate blockchain network connections', () => {
         '{ "8996":{ "rpc":"http://127.0.0.1:8545", "fallbackRPCs": ["http://127.0.0.3:8545","http://127.0.0.1:8545"], "chainId": 8996, "network": "development", "chunkSize": 100 }}'
       ]
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
 
     rpcs = config.supportedNetworks

--- a/src/test/unit/blockchain.test.ts
+++ b/src/test/unit/blockchain.test.ts
@@ -25,7 +25,7 @@ describe('Should validate blockchain network connections', () => {
     envOverrides = buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.RPCS],
       [
-        '{ "8996":{ "rpc":"http://172.0.0.1:8545", "fallbackRPCs": ["http://172.0.0.3:8545","http://127.0.0.1:8545"], "chainId": 8996, "network": "development", "chunkSize": 100 }}'
+        '{ "8996":{ "rpc":"http://127.0.0.1:8545", "fallbackRPCs": ["http://127.0.0.3:8545","http://127.0.0.1:8545"], "chainId": 8996, "network": "development", "chunkSize": 100 }}'
       ]
     )
     envOverrides = await setupEnvironment(null, envOverrides)

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -24,7 +24,8 @@ import {
   buildEnvOverrideConfig,
   OverrideEnvConfig,
   setupEnvironment,
-  tearDownEnvironment
+  tearDownEnvironment,
+  TEST_ENV_CONFIG_FILE
 } from '../utils/utils.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { ENVIRONMENT_VARIABLES } from '../../utils/constants.js'
@@ -54,7 +55,7 @@ describe('Compute Jobs Database', () => {
         '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
       ]
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
     db = await new C2DDatabase(config.dbConfig, typesenseSchemas.c2dSchemas)
   })

--- a/src/test/unit/credentials.test.ts
+++ b/src/test/unit/credentials.test.ts
@@ -8,7 +8,8 @@ import {
   buildEnvOverrideConfig,
   OverrideEnvConfig,
   setupEnvironment,
-  tearDownEnvironment
+  tearDownEnvironment,
+  TEST_ENV_CONFIG_FILE
 } from '../utils/utils.js'
 import { ENVIRONMENT_VARIABLES } from '../../utils/constants.js'
 import { homedir } from 'os'
@@ -25,7 +26,7 @@ describe('credentials', () => {
         `${homedir}/.ocean/ocean-contracts/artifacts/address.json`
       ]
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
   })
 
   it('should allow access with undefined or empty credentials', () => {

--- a/src/test/unit/download.test.ts
+++ b/src/test/unit/download.test.ts
@@ -10,6 +10,7 @@ import { Readable } from 'stream'
 import { streamToString } from '../../utils/util.js'
 import {
   OverrideEnvConfig,
+  TEST_ENV_CONFIG_FILE,
   buildEnvOverrideConfig,
   setupEnvironment,
   tearDownEnvironment
@@ -31,7 +32,7 @@ describe('Should validate files structure for download', () => {
       [ENVIRONMENT_VARIABLES.PRIVATE_KEY],
       ['0x3634cc4a3d2694a1186a7ce545f149e022eea103cc254d18d08675104bb4b5ac']
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
     db = await new Database(config.dbConfig)
     oceanNode = OceanNode.getInstance(config, db)

--- a/src/test/unit/download.test.ts
+++ b/src/test/unit/download.test.ts
@@ -34,7 +34,7 @@ describe('Should validate files structure for download', () => {
     )
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
-    db = await new Database(config.dbConfig)
+    db = await Database.init(config.dbConfig)
     oceanNode = OceanNode.getInstance(config, db)
   })
 

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -12,7 +12,8 @@ import {
   buildEnvOverrideConfig,
   OverrideEnvConfig,
   setupEnvironment,
-  tearDownEnvironment
+  tearDownEnvironment,
+  TEST_ENV_CONFIG_FILE
 } from '../../utils/utils.js'
 
 describe('OceanIndexer', () => {
@@ -27,7 +28,7 @@ describe('OceanIndexer', () => {
         '{ "8996":{ "rpc":"http://127.0.0.1:8545", "fallbackRPCs": ["http://127.0.0.3:8545","http://127.0.0.1:8545"], "chainId": 8996, "network": "development", "chunkSize": 100 }}'
       ]
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
     mockDatabase = await new Database(config.dbConfig)
     console.log('mockDatabase: ', mockDatabase)

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -42,17 +42,17 @@ describe('OceanIndexer', () => {
       indexer: {},
       logs: {},
       order: {},
-      ddoState: {}
+      ddoState: {},
+      getConfig: () => config.dbConfig
     } as any)
-    mockDatabase = await Database.init(config.dbConfig)
-    console.log('mockDatabase: ', mockDatabase)
-    console.log('config.dbConfig: ', JSON.stringify(config.dbConfig))
   })
 
   it('should start threads and handle worker events', async () => {
+    mockDatabase = await Database.init(config.dbConfig)
+    console.log('mockDatabase: ', mockDatabase)
+    console.log('config.dbConfig: ', JSON.stringify(config.dbConfig))
     oceanIndexer = new OceanIndexer(mockDatabase, config.supportedNetworks)
     assert(oceanIndexer, 'indexer should not be null')
-    console.log('mockDatabase: ', mockDatabase)
     expect(oceanIndexer.getDatabase().getConfig()).to.be.equal(mockDatabase.getConfig())
     expect(oceanIndexer.getIndexingQueue().length).to.be.equal(0)
     expect(oceanIndexer.getJobsPool().length).to.be.equal(0)

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -30,7 +30,7 @@ describe('OceanIndexer', () => {
     )
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
-    mockDatabase = await new Database(config.dbConfig)
+    mockDatabase = await Database.init(config.dbConfig)
     console.log('mockDatabase: ', mockDatabase)
     console.log('config.dbConfig: ', JSON.stringify(config.dbConfig))
   })

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -30,11 +30,14 @@ describe('OceanIndexer', () => {
     envOverrides = await setupEnvironment(null, envOverrides)
     config = await getConfiguration(true)
     mockDatabase = await new Database(config.dbConfig)
+    console.log('mockDatabase: ', mockDatabase)
+    console.log('config.dbConfig: ', JSON.stringify(config.dbConfig))
   })
 
   it('should start threads and handle worker events', async () => {
     oceanIndexer = new OceanIndexer(mockDatabase, config.supportedNetworks)
     assert(oceanIndexer, 'indexer should not be null')
+    console.log('mockDatabase: ', mockDatabase)
     expect(oceanIndexer.getDatabase().getConfig()).to.be.equal(mockDatabase.getConfig())
     expect(oceanIndexer.getIndexingQueue().length).to.be.equal(0)
     expect(oceanIndexer.getJobsPool().length).to.be.equal(0)

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -1,19 +1,33 @@
 import { assert, expect } from 'chai'
 import { describe, it } from 'mocha'
 import { OceanIndexer } from '../../../components/Indexer/index.js'
-import { getConfiguration } from '../../../utils/index.js'
+import { ENVIRONMENT_VARIABLES, getConfiguration } from '../../../utils/index.js'
 import { Database } from '../../../components/database/index.js'
 import { OceanNodeConfig } from '../../../@types/OceanNode.js'
 import {
   hasValidDBConfiguration,
   isReachableConnection
 } from '../../../utils/database.js'
+import {
+  buildEnvOverrideConfig,
+  OverrideEnvConfig,
+  setupEnvironment,
+  tearDownEnvironment
+} from '../../utils/utils.js'
 
 describe('OceanIndexer', () => {
+  let envOverrides: OverrideEnvConfig[]
   let oceanIndexer: OceanIndexer
   let mockDatabase: Database
   let config: OceanNodeConfig
   before(async () => {
+    envOverrides = buildEnvOverrideConfig(
+      [ENVIRONMENT_VARIABLES.RPCS],
+      [
+        '{ "8996":{ "rpc":"http://127.0.0.1:8545", "fallbackRPCs": ["http://127.0.0.3:8545","http://127.0.0.1:8545"], "chainId": 8996, "network": "development", "chunkSize": 100 }}'
+      ]
+    )
+    envOverrides = await setupEnvironment(null, envOverrides)
     config = await getConfiguration(true)
     mockDatabase = await new Database(config.dbConfig)
   })
@@ -38,5 +52,8 @@ describe('OceanIndexer', () => {
 
     // there are no worker threads available
     expect(oceanIndexer.stopAllThreads()).to.be.equal(false)
+  })
+  after(async () => {
+    await tearDownEnvironment(envOverrides)
   })
 })

--- a/src/test/unit/indexer/indexer.test.ts
+++ b/src/test/unit/indexer/indexer.test.ts
@@ -15,12 +15,14 @@ import {
   tearDownEnvironment,
   TEST_ENV_CONFIG_FILE
 } from '../../utils/utils.js'
+import sinon, { SinonSandbox } from 'sinon'
 
 describe('OceanIndexer', () => {
   let envOverrides: OverrideEnvConfig[]
   let oceanIndexer: OceanIndexer
   let mockDatabase: Database
   let config: OceanNodeConfig
+  let sandbox: SinonSandbox
   before(async () => {
     envOverrides = buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.RPCS],
@@ -30,6 +32,18 @@ describe('OceanIndexer', () => {
     )
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     config = await getConfiguration(true)
+    sandbox = sinon.createSandbox()
+    sandbox.stub(Database, 'init').resolves({
+      nonce: {},
+      c2d: {},
+      authToken: {},
+      sqliteConfig: {},
+      ddo: {},
+      indexer: {},
+      logs: {},
+      order: {},
+      ddoState: {}
+    } as any)
     mockDatabase = await Database.init(config.dbConfig)
     console.log('mockDatabase: ', mockDatabase)
     console.log('config.dbConfig: ', JSON.stringify(config.dbConfig))
@@ -59,5 +73,6 @@ describe('OceanIndexer', () => {
   })
   after(async () => {
     await tearDownEnvironment(envOverrides)
+    sandbox.restore()
   })
 })

--- a/src/test/unit/indexer/validation.test.ts
+++ b/src/test/unit/indexer/validation.test.ts
@@ -48,7 +48,7 @@ describe('Schema validation tests', () => {
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     wallet = new ethers.Wallet(privateKey)
     config = await getConfiguration()
-    database = await new Database(config.dbConfig)
+    database = await Database.init(config.dbConfig)
     oceanNode = await OceanNode.getInstance(
       config,
       database,

--- a/src/test/unit/indexer/validation.test.ts
+++ b/src/test/unit/indexer/validation.test.ts
@@ -7,7 +7,8 @@ import {
   tearDownEnvironment,
   buildEnvOverrideConfig,
   OverrideEnvConfig,
-  getMockSupportedNetworks
+  getMockSupportedNetworks,
+  TEST_ENV_CONFIG_FILE
 } from '../../utils/utils.js'
 import { DDOManager, DDO } from '@oceanprotocol/ddo-js'
 import { ValidateDDOHandler } from '../../../components/core/handler/ddoHandler.js'
@@ -44,7 +45,7 @@ describe('Schema validation tests', () => {
         JSON.stringify(mockSupportedNetworks)
       ]
     )
-    envOverrides = await setupEnvironment(null, envOverrides)
+    envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
     wallet = new ethers.Wallet(privateKey)
     config = await getConfiguration()
     database = await new Database(config.dbConfig)

--- a/src/test/unit/logging.test.ts
+++ b/src/test/unit/logging.test.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import {
   DEFAULT_TEST_TIMEOUT,
   OverrideEnvConfig,
+  TEST_ENV_CONFIG_FILE,
   buildEnvOverrideConfig,
   setupEnvironment,
   tearDownEnvironment
@@ -25,7 +26,7 @@ describe('Logger instances and transports tests', async () => {
   before(() => {})
   // need to do it first
   envOverrides = await setupEnvironment(
-    null,
+    TEST_ENV_CONFIG_FILE,
     buildEnvOverrideConfig(
       [
         ENVIRONMENT_VARIABLES.NODE_ENV,

--- a/src/test/unit/logging.test.ts
+++ b/src/test/unit/logging.test.ts
@@ -59,7 +59,7 @@ describe('Logger instances and transports tests', async () => {
     // will build the DB transport layer
     const config = await getConfiguration(true)
     // eslint-disable-next-line no-unused-vars
-    const DB = await new Database(config.dbConfig)
+    const DB = await Database.init(config.dbConfig)
     // Could generate Typesene error if DB is not running, but does not matter for this test
     OCEAN_NODE_LOGGER.logMessage('Should build DB transport layer')
 

--- a/src/test/unit/networking.test.ts
+++ b/src/test/unit/networking.test.ts
@@ -10,6 +10,7 @@ import { expect } from 'chai'
 import {
   DEFAULT_TEST_TIMEOUT,
   OverrideEnvConfig,
+  TEST_ENV_CONFIG_FILE,
   buildEnvOverrideConfig,
   setupEnvironment,
   tearDownEnvironment
@@ -146,7 +147,7 @@ describe('Test rate limitations and deny list settings', () => {
         3
       ]
     )
-    await setupEnvironment(null, envOverrides)
+    await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
   })
 
   it('should read deny list of other peers and ips', async () => {

--- a/src/test/unit/ocean.test.ts
+++ b/src/test/unit/ocean.test.ts
@@ -37,7 +37,7 @@ describe('Status command tests', async () => {
   envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
   // because of this
   const config = await getConfiguration(true)
-  const db = await new Database(config.dbConfig)
+  const db = await Database.init(config.dbConfig)
   const oceanP2P = new OceanP2P(config, db)
   const oceanIndexer = new OceanIndexer(db, config.indexingNetworks)
   const oceanProvider = new OceanProvider(db)

--- a/src/test/unit/ocean.test.ts
+++ b/src/test/unit/ocean.test.ts
@@ -8,6 +8,7 @@ import { ENVIRONMENT_VARIABLES, getConfiguration } from '../../utils/index.js'
 import { expect } from 'chai'
 import {
   OverrideEnvConfig,
+  TEST_ENV_CONFIG_FILE,
   buildEnvOverrideConfig,
   setupEnvironment,
   tearDownEnvironment
@@ -33,7 +34,7 @@ describe('Status command tests', async () => {
       JSON.stringify([1, 137])
     ]
   )
-  envOverrides = await setupEnvironment(null, envOverrides)
+  envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
   // because of this
   const config = await getConfiguration(true)
   const db = await new Database(config.dbConfig)

--- a/src/test/unit/oceanP2P.test.ts
+++ b/src/test/unit/oceanP2P.test.ts
@@ -29,8 +29,8 @@ describe('OceanP2P Test', () => {
       '0x3634cc4a3d2694a1186a7ce545f149e022eea103cc254d18d08675104bb4b5ac'
     ]
   )
-  before(() => {
-    setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
+  before(async () => {
+    await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)
   })
 
   it('Start instance of OceanP2P node1', async () => {

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -13,7 +13,7 @@ export async function getDatabase(forceReload: boolean = false): Promise<Databas
   if (!dbConnection || forceReload) {
     const { dbConfig } = await getConfiguration(true)
     if (dbConfig && dbConfig.url) {
-      dbConnection = await new Database(dbConfig)
+      dbConnection = await Database.init(dbConfig)
     }
   }
   return dbConnection


### PR DESCRIPTION
Fixes #1000 #1001  .

Changes proposed in this PR:

- added setup environment and tear down env for indexer unit tests
- update RPCs for unit tests
- replace DB constructor with init async method + try-catch blocks to every db initialization