### PR TITLE
Await P2P Provide handle

### DIFF
--- a/src/components/P2P/index.ts
+++ b/src/components/P2P/index.ts
@@ -772,7 +772,9 @@ export class OceanP2P extends EventEmitter {
       if (x > 0) {
         const multiAddrs = this._libp2p.components.addressManager.getAddresses()
         // console.log('multiaddrs: ', multiAddrs)
-        await this._libp2p.contentRouting.provide(cid, multiAddrs)
+        this._libp2p.contentRouting.provide(cid, multiAddrs).catch((err: any) => {
+          P2P_LOGGER.error(`Error advertising DDO: ${err}`)
+        })
       } else {
         P2P_LOGGER.debug(
           'Could not find any Ocean peers. Nobody is listening at the moment, skipping...'


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- contentRouting.provide() is an async method which was not awaited, use await to avoid unhandled exceptions

Reference: https://www.npmjs.com/package/@libp2p/interface-content-routing
