### PR TITLE
Allow environment variables for algorithms

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1242,6 +1242,7 @@ It can include information about the file object, document ID, service ID, trans
 - **transferTxId**: Optional. A string representing the transaction ID for the transfer of the compute algorithm.
 - **algocustomdata**: Optional. An object containing additional custom data related to the compute algorithm.
 - **userdata**: Optional. An object containing additional user-defined data related to the compute algorithm.
+- **envs**: Optional. Array of keys:values to be used as environment variables for algo.
 
 ```typescript
 export interface ComputeAlgorithm {

--- a/src/@types/C2D/C2D.ts
+++ b/src/@types/C2D/C2D.ts
@@ -189,6 +189,7 @@ export interface ComputeAlgorithm {
   transferTxId?: string
   algocustomdata?: { [key: string]: any }
   userdata?: { [key: string]: any }
+  envs?: { [key: string]: any }
 }
 
 export interface AlgoChecksums {

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -857,6 +857,13 @@ export class C2DEngineDocker extends C2DEngine {
         )
         containerInfo.Entrypoint = newEntrypoint.split(' ')
       }
+      if (job.algorithm.envs) {
+        const envVars: string[] = []
+        for (const key of Object.keys(job.algorithm.envs)) {
+          envVars.push(`${key}=${job.algorithm.envs[key]}`)
+        }
+        containerInfo.Env = envVars
+      }
       const container = await this.createDockerContainer(containerInfo, true)
       if (container) {
         console.log('Container created: ', container)


### PR DESCRIPTION
Introduce an optional `envs` property to the `ComputeAlgorithm` interface, enabling the specification of environment variables for algorithms in the C2D engine.

Closes #1031