### PR TITLE
Add friendly name to node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eth-crypto": "^2.6.0",
         "ethers": "^6.8.1",
         "express": "^4.21.1",
+        "humanhash": "^1.0.4",
         "hyperdiff": "^2.0.16",
         "ip": "^2.0.1",
         "it-pipe": "^3.0.1",
@@ -10921,6 +10922,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/humanhash": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/humanhash/-/humanhash-1.0.4.tgz",
+      "integrity": "sha512-fxOhEl/Ezv7PobYOTomDmQKWaSC0hk0mzl5et5McPtr+6LRBP7LYoeFLPjKW6xOSGmMNLj50BufrrgX+M5EvEA==",
+      "license": "Unlicense",
+      "dependencies": {
+        "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/humanhash/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/humanize-ms": {
@@ -26772,6 +26792,21 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "humanhash": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/humanhash/-/humanhash-1.0.4.tgz",
+      "integrity": "sha512-fxOhEl/Ezv7PobYOTomDmQKWaSC0hk0mzl5et5McPtr+6LRBP7LYoeFLPjKW6xOSGmMNLj50BufrrgX+M5EvEA==",
+      "requires": {
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "humanize-ms": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eth-crypto": "^2.6.0",
     "ethers": "^6.8.1",
     "express": "^4.21.1",
+    "humanhash": "^1.0.4",
     "hyperdiff": "^2.0.16",
     "ip": "^2.0.1",
     "it-pipe": "^3.0.1",

--- a/src/@types/OceanNode.ts
+++ b/src/@types/OceanNode.ts
@@ -146,6 +146,7 @@ export interface StorageTypes {
 export interface OceanNodeStatus {
   id: string
   publicKey: string
+  friendlyName: string
   address: string
   version: string
   http: boolean

--- a/src/@types/humanhash.d.ts
+++ b/src/@types/humanhash.d.ts
@@ -1,9 +1,13 @@
 declare module 'humanhash' {
-    class HumanHasher {
-        constructor(wordlist?: string[])
-        humanize(hexdigest: string, words?: number, separator?: string): string
-        uuid(words?: number, separator?: string, version?: number): { humanhash: string; uuid: string }
-    }
+  class HumanHasher {
+    constructor(wordlist?: string[])
+    humanize(hexdigest: string, words?: number, separator?: string): string
+    uuid(
+      words?: number,
+      separator?: string,
+      version?: number
+    ): { humanhash: string; uuid: string }
+  }
 
-    export = HumanHasher
+  export = HumanHasher
 }

--- a/src/@types/humanhash.d.ts
+++ b/src/@types/humanhash.d.ts
@@ -1,0 +1,9 @@
+declare module 'humanhash' {
+    class HumanHasher {
+        constructor(wordlist?: string[])
+        humanize(hexdigest: string, words?: number, separator?: string): string
+        uuid(words?: number, separator?: string, version?: number): { humanhash: string; uuid: string }
+    }
+
+    export = HumanHasher
+}

--- a/src/components/core/utils/statusHandler.ts
+++ b/src/components/core/utils/statusHandler.ts
@@ -14,6 +14,7 @@ import { OceanNode } from '../../../OceanNode.js'
 import { typesenseSchemas } from '../../database/TypesenseSchemas.js'
 import { SupportedNetwork } from '../../../@types/blockchain.js'
 import { getAdminAddresses } from '../../../utils/auth.js'
+import HumanHasher from 'humanhash'
 
 const supportedStorageTypes: StorageTypes = {
   url: true,
@@ -106,9 +107,11 @@ export async function status(
 
   // no previous status?
   if (!nodeStatus) {
+    const publicKeyHex = Buffer.from(config.keys.publicKey).toString('hex')
     nodeStatus = {
       id: nodeId && nodeId !== undefined ? nodeId : config.keys.peerId.toString(), // get current node ID
-      publicKey: Buffer.from(config.keys.publicKey).toString('hex'),
+      publicKey: publicKeyHex,
+      friendlyName: new HumanHasher().humanize(publicKeyHex),
       address: config.keys.ethAddress,
       version: process.env.npm_package_version,
       http: config.hasHttp,


### PR DESCRIPTION
Fixes #1040 

Changes proposed in this PR:

- Add friendly name derived from public key
- 4 words for friendlyName (default)

```
Response { "command": "status" }

{
    "id": "16Uiu2HAm7tJg8MXgUzxxUXi55dVL86MNsrSJiLS3EjxWRqvTTEGw",
    "publicKey": "0802122102b91ed5f65fbb9e7a76dd97b122af57df99fadc7924aff7435d384de980144f40",
    "friendlyName": "salami-pip-jig-video",
    "address": "0x6D91c0Cd4588E7986Bd7A859C0EE22762c2BE06E",
    "version": "0.2.3",
    "http": true,
    "p2p": true,
    ....
 }
```
