### PR TITLE
Fix/disk_ram_in_gb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
           DB_TYPE: 'elasticsearch'
           MAX_REQ_PER_MINUTE: 320
           MAX_CONNECTIONS_PER_MINUTE: 320
-          DOCKER_COMPUTE_ENVIRONMENTS: '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"8996":[{"prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+          DOCKER_COMPUTE_ENVIRONMENTS: '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"8996":[{"prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
       - name: Check Ocean Node is running
         run: |
           for i in $(seq 1 90); do

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -82,7 +82,7 @@ Here is the full definition of DOCKER_COMPUTE_ENVIRONMENTS:
           }
         }
       },
-      { "id": "disk", "total": 1000000000 }
+      { "id": "disk", "total": 1 }
     ],
     "storageExpiry": 604800,
     "maxJobDuration": 3600,
@@ -102,8 +102,8 @@ Here is the full definition of DOCKER_COMPUTE_ENVIRONMENTS:
       "maxJobs": 3,
       "resources": [
         { "id": "cpu", "max": 1 },
-        { "id": "ram", "max": 1000000000 },
-        { "id": "disk", "max": 1000000000 },
+        { "id": "ram", "max": 1 },
+        { "id": "disk", "max": 1 },
         { "id": "myGPU", "max": 1 }
       ]
     }
@@ -141,9 +141,9 @@ root@gpu-1:/repos/ocean/ocean-node# curl http://localhost:8000/api/services/comp
       { "id": "cpu", "total": 8, "max": 8, "min": 1, "inUse": 0 },
       {
         "id": "ram",
-        "total": 24888963072,
-        "max": 24888963072,
-        "min": 1000000000,
+        "total": 23,
+        "max": 23,
+        "min": 1,
         "inUse": 0
       },
       {
@@ -162,15 +162,15 @@ root@gpu-1:/repos/ocean/ocean-node# curl http://localhost:8000/api/services/comp
         "min": 0,
         "inUse": 0
       },
-      { "id": "disk", "total": 1000000000, "max": 1000000000, "min": 0, "inUse": 0 }
+      { "id": "disk", "total": 1, "max": 1, "min": 0, "inUse": 0 }
     ],
     "free": {
       "maxJobDuration": 60,
       "maxJobs": 3,
       "resources": [
         { "id": "cpu", "max": 1, "inUse": 0 },
-        { "id": "ram", "max": 1000000000, "inUse": 0 },
-        { "id": "disk", "max": 1000000000, "inUse": 0 },
+        { "id": "ram", "max": 1, "inUse": 0 },
+        { "id": "disk", "max": 1, "inUse": 0 },
         { "id": "myGPU", "max": 1, "inUse": 0 }
       ]
     },
@@ -259,7 +259,7 @@ Then define DOCKER_COMPUTE_ENVIRONMENTS with
       },
       {
         "id": "disk",
-        "total": 1000000000
+        "total": 1
       }
     ],
     "storageExpiry": 604800,
@@ -291,11 +291,11 @@ Then define DOCKER_COMPUTE_ENVIRONMENTS with
         },
         {
           "id": "ram",
-          "max": 1000000000
+          "max": 1
         },
         {
           "id": "disk",
-          "max": 1000000000
+          "max": 1
         },
         {
           "id": "myGPU",
@@ -311,7 +311,7 @@ aka
 
 ```bash
 export DOCKER_COMPUTE_ENVIRONMENTS="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"myGPU\",\"description\":\"AMD Radeon RX 9070 XT\",\"type\":\"gpu\",\"total\":1,\"init\":{\"advanced\":{
-\"IpcMode\":\"host\",\"CapAdd\":[\"CAP_SYS_PTRACE\"],\"Devices\":[\"/dev/dxg\",\"/dev/dri/card0\"],\"Binds\":[\"/usr/lib/wsl/lib/libdxcore.so:/usr/lib/libdxcore.so\",\"/opt/rocm/lib/libhsa-runtime64.so.1:/opt/rocm/lib/libhsa-runtime64.so.1\"],\"SecurityOpt\":{\"seccomp\":\"unconfined\"}}}},{\"id\":\"disk\",\"total\":1000000000}],\"storageExpiry\":604800,\"maxJobDuration\":3600,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1},{\"id\":\"nyGPU\",\"price\":3}]}]},\"free\":{\"maxJobDuration\":60,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1000000000},{\"id\":\"disk\",\"max\":1000000000},{\"id\":\"myGPU\",\"max\":1}]}}]"
+\"IpcMode\":\"host\",\"CapAdd\":[\"CAP_SYS_PTRACE\"],\"Devices\":[\"/dev/dxg\",\"/dev/dri/card0\"],\"Binds\":[\"/usr/lib/wsl/lib/libdxcore.so:/usr/lib/libdxcore.so\",\"/opt/rocm/lib/libhsa-runtime64.so.1:/opt/rocm/lib/libhsa-runtime64.so.1\"],\"SecurityOpt\":{\"seccomp\":\"unconfined\"}}}},{\"id\":\"disk\",\"total\":10}],\"storageExpiry\":604800,\"maxJobDuration\":3600,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1},{\"id\":\"nyGPU\",\"price\":3}]}]},\"free\":{\"maxJobDuration\":60,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1},{\"id\":\"disk\",\"max\":1},{\"id\":\"myGPU\",\"max\":1}]}}]"
 ```
 
 you should have it in your compute envs:
@@ -359,9 +359,9 @@ root@gpu-1:/repos/ocean/ocean-node# curl http://localhost:8000/api/services/comp
       },
       {
         "id": "ram",
-        "total": 33617674240,
-        "max": 33617674240,
-        "min": 1000000000,
+        "total": 31,
+        "max": 31,
+        "min": 1,
         "inUse": 0
       },
       {
@@ -389,8 +389,8 @@ root@gpu-1:/repos/ocean/ocean-node# curl http://localhost:8000/api/services/comp
       },
       {
         "id": "disk",
-        "total": 1000000000,
-        "max": 1000000000,
+        "total": 10,
+        "max": 10,
         "min": 0,
         "inUse": 0
       }
@@ -406,12 +406,12 @@ root@gpu-1:/repos/ocean/ocean-node# curl http://localhost:8000/api/services/comp
         },
         {
           "id": "ram",
-          "max": 1000000000,
+          "max": 1,
           "inUse": 0
         },
         {
           "id": "disk",
-          "max": 1000000000,
+          "max": 1,
           "inUse": 0
         },
         {

--- a/docs/env.md
+++ b/docs/env.md
@@ -124,6 +124,8 @@ The `DOCKER_COMPUTE_ENVIRONMENTS` environment variable is used to configure Dock
 Example Configuration
 The `DOCKER_COMPUTE_ENVIRONMENTS` environment variable should be a JSON array of objects, where each object represents a Docker compute environment configuration. Below is an example configuration:
 
+`Disk` and `Ram` resources are always expressed in GB.
+
 ```json
 [
   {
@@ -131,7 +133,7 @@ The `DOCKER_COMPUTE_ENVIRONMENTS` environment variable should be a JSON array of
     "resources": [
       {
         "id": "disk",
-        "total": 1000000000
+        "total": 10
       }
     ],
     "storageExpiry": 604800,
@@ -159,11 +161,11 @@ The `DOCKER_COMPUTE_ENVIRONMENTS` environment variable should be a JSON array of
         },
         {
           "id": "ram",
-          "max": 1000000000
+          "max": 1
         },
         {
           "id": "disk",
-          "max": 1000000000
+          "max": 1
         }
       ]
     }

--- a/scripts/ocean-node-quickstart.sh
+++ b/scripts/ocean-node-quickstart.sh
@@ -142,7 +142,7 @@ fi
 # Set default compute environments if not already defined
 if [ -z "$DOCKER_COMPUTE_ENVIRONMENTS" ]; then
   echo "Setting default DOCKER_COMPUTE_ENVIRONMENTS configuration"
-  export DOCKER_COMPUTE_ENVIRONMENTS="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"disk\",\"total\":1000000000}],\"storageExpiry\":604800,\"maxJobDuration\":36000,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]},\"free\":{\"maxJobDuration\":360000,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1000000000},{\"id\":\"disk\",\"max\":1000000000}]}}]"
+  export DOCKER_COMPUTE_ENVIRONMENTS="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"disk\",\"total\":10}],\"storageExpiry\":604800,\"maxJobDuration\":36000,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]},\"free\":{\"maxJobDuration\":360000,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1},{\"id\":\"disk\",\"max\":1}]}}]"
 fi
 
 cat <<EOF > docker-compose.yml

--- a/scripts/ocean-node-update.sh
+++ b/scripts/ocean-node-update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEFAULT_DOCKER_ENVIRONMENTS='[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":36000,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":360000,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+DEFAULT_DOCKER_ENVIRONMENTS='[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":36000,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":360000,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
 
 check_prerequisites() {
     if [ ! -f "docker-compose.yml" ]; then

--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -35,7 +35,8 @@ function getInternalStructure(job: DBComputeJob): any {
     algoStartTimestamp: job.algoStartTimestamp,
     algoStopTimestamp: job.algoStopTimestamp,
     metadata: job.metadata,
-    additionalViewers: job.additionalViewers
+    additionalViewers: job.additionalViewers,
+    terminationDetails: job.terminationDetails
   }
   return internalBlob
 }

--- a/src/helpers/scripts/setupNodeEnv.sh
+++ b/src/helpers/scripts/setupNodeEnv.sh
@@ -255,7 +255,7 @@ if [ "$enable_compute" == 'y' ]; then
     echo "   You can customize this in your .env file for production use."
     echo ""
     
-    DOCKER_COMPUTE_ENV="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"disk\",\"total\":1000000000}],\"storageExpiry\":604800,\"maxJobDuration\":36000,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]},\"free\":{\"maxJobDuration\":360000,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1000000000},{\"id\":\"disk\",\"max\":1000000000}]}}]"
+    DOCKER_COMPUTE_ENV="[{\"socketPath\":\"/var/run/docker.sock\",\"resources\":[{\"id\":\"disk\",\"total\":10}],\"storageExpiry\":604800,\"maxJobDuration\":36000,\"fees\":{\"1\":[{\"feeToken\":\"0x123\",\"prices\":[{\"id\":\"cpu\",\"price\":1}]}]},\"free\":{\"maxJobDuration\":360000,\"maxJobs\":3,\"resources\":[{\"id\":\"cpu\",\"max\":1},{\"id\":\"ram\",\"max\":1},{\"id\":\"disk\",\"max\":1}]}}]"
     
     REPLACE_STR="DOCKER_COMPUTE_ENVIRONMENTS='$DOCKER_COMPUTE_ENV'"
     if [ "$(uname)" == "Darwin" ]; then

--- a/src/test/integration/algorithmsAccess.test.ts
+++ b/src/test/integration/algorithmsAccess.test.ts
@@ -99,11 +99,11 @@ describe('Trusted algorithms Flow', () => {
           '0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58',
           JSON.stringify(['0xe2DD09d719Da89e5a3D0F2549c7E24566e947260']),
           `${homedir}/.ocean/ocean-contracts/artifacts/address.json`,
-          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
+          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
             DEVELOPMENT_CHAIN_ID +
             '":[{"feeToken":"' +
             paymentToken +
-            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
         ]
       )
     )

--- a/src/test/integration/compute.test.ts
+++ b/src/test/integration/compute.test.ts
@@ -145,11 +145,11 @@ describe('Compute', () => {
           '0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58',
           JSON.stringify(['0xe2DD09d719Da89e5a3D0F2549c7E24566e947260']),
           `${homedir}/.ocean/ocean-contracts/artifacts/address.json`,
-          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
+          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
             DEVELOPMENT_CHAIN_ID +
             '":[{"feeToken":"' +
             paymentToken +
-            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
         ]
       )
     )

--- a/src/test/integration/credentials.test.ts
+++ b/src/test/integration/credentials.test.ts
@@ -125,11 +125,11 @@ describe('[Credentials Flow] - Should run a complete node flow.', () => {
             await publisherAccount.getAddress() // signer 0
           ]),
           `${homedir}/.ocean/ocean-contracts/artifacts/address.json`,
-          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
+          '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"' +
             DEVELOPMENT_CHAIN_ID +
             '":[{"feeToken":"' +
             paymentToken +
-            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+            '","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
         ]
       )
     )

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -52,7 +52,7 @@ describe('Compute Jobs Database', () => {
     envOverrides = buildEnvOverrideConfig(
       [ENVIRONMENT_VARIABLES.DOCKER_COMPUTE_ENVIRONMENTS],
       [
-        '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":1000000000}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1000000000},{"id":"disk","max":1000000000}]}}]'
+        '[{"socketPath":"/var/run/docker.sock","resources":[{"id":"disk","total":10}],"storageExpiry":604800,"maxJobDuration":3600,"fees":{"1":[{"feeToken":"0x123","prices":[{"id":"cpu","price":1}]}]},"free":{"maxJobDuration":60,"maxJobs":3,"resources":[{"id":"cpu","max":1},{"id":"ram","max":1},{"id":"disk","max":1}]}}]'
       ]
     )
     envOverrides = await setupEnvironment(TEST_ENV_CONFIG_FILE, envOverrides)


### PR DESCRIPTION
Fixes #1041

Changes proposed in this PR:

- `ram` and `disk` resources are always expressed in GB
- fix error:
```
"message":"uncaughtException: Cannot set properties of undefined (setting 'OOMKilled')\nTypeError: Cannot set properties of undefined (setting 'OOMKilled')\n    at C2DEngineDocker.processJob (file:///repos/ocean/ocean-node/dist/components/c2d/compute_engine_docker.js:763:50)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Promise.all (index 0)\n    at async C2DEngineDocker.InternalLoop (file:///repos/ocean/ocean-node/dist/components/c2d/compute_engine_docker.js:466:9)","os":{"loadavg":[0.34,0.39,0.33],"uptime":407447.95},"process":{"argv":["/root/.nvm/versions/node/v20.19.0/bin/node","/repos/ocean/ocean-node/dist/index.js"]
```
- 