### PR TITLE
chore: fix algo validation

### DIFF
--- a/src/components/core/compute/utils.ts
+++ b/src/components/core/compute/utils.ts
@@ -126,7 +126,7 @@ export async function validateAlgoForDataset(
         })
 
       // Check if algorithm publisher is trusted
-      let isPublisherTrusted = true
+      let isPublisherTrusted = false
       if (hasTrustedPublishers) {
         if (!publishers.includes('*')) {
           const algoDDO = await new FindDdoHandler(oceanNode).findAndFormatDdo(algoDID)
@@ -137,10 +137,12 @@ export async function validateAlgoForDataset(
           isPublisherTrusted = publishers
             .map((addr: string) => addr?.toLowerCase())
             .includes(nftAddress?.toLowerCase())
+        } else {
+          isPublisherTrusted = true
         }
       }
 
-      return isAlgoTrusted && isPublisherTrusted
+      return isAlgoTrusted || isPublisherTrusted
     }
 
     return compute.allowRawAlgorithm


### PR DESCRIPTION
Changes proposed in this PR:

Updated the  validateAlgoForDataset  logic to correctly handle the following cases:
	•	The algorithm should pass validation if it matches either  publisherTrustedAlgorithms  or publisherTrustedAlgorithmPublishers .
	•	It should not be required to appear in both lists simultaneously.
	
Example:
```
        "compute": {
          "publisherTrustedAlgorithms": [
            {
              "filesChecksum": "2c36c054711dad021f45cc7e0990bd38864a51d753c8055b63e78014a6bee515",
              "containerSectionChecksum": "ad2e6cf7e1997f2c95098b8a968251d645b29ba1047ceab23d4765cda5b4754a",
              "serviceId": "9ce2ebf988ae1ded0c409248fca32ff7c8288fca560af818bb2fbefd990d94e8",
              "did": "did:ope:bf25f53071fd49d9b3e733032f25943539d92f97ff787a031461625987f5ad0c"
            }
          ],
          "publisherTrustedAlgorithmPublishers": [
            "*"
          ],
          "allowRawAlgorithm": false,
          "allowNetworkAccess": true
        }
  ```
  
In this configuration, all algorithms should pass validation because the wildcard  "*"  in publisherTrustedAlgorithmPublishers  allows any publisher. Previously, only the algorithms listed under publisherTrustedAlgorithms  would pass.