### PR TITLE
build arm versions only on release and main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-          - linux/arm/v7
+        platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64","linux/arm64","linux/arm/v7"]') }}
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
The workflow now uses a conditional matrix:
Pull requests: Only builds linux/amd64
Main branch pushes, version tags (v..), and manual dispatches: Builds all three platforms (linux/amd64, linux/arm64, linux/arm/v7)
This reduces build time and resource usage for PRs while keeping multi-platform builds for releases and main branch.