### PR TITLE
fix: update signature validation

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -53,18 +53,20 @@ export async function validateAdminSignature(
     if (allowed) {
       return { valid: true, error: '' }
     }
-    for (const chainId of Object.keys(accessLists)) {
-      allowed = await checkSingleCredential(
-        {
-          type: CREDENTIALS_TYPES.ACCESS_LIST,
-          chainId: parseInt(chainId),
-          accessList: accessLists[chainId]
-        },
-        signerAddress,
-        null
-      )
-      if (allowed) {
-        return { valid: true, error: '' }
+    if (accessLists) {
+      for (const chainId of Object.keys(accessLists)) {
+        allowed = await checkSingleCredential(
+          {
+            type: CREDENTIALS_TYPES.ACCESS_LIST,
+            chainId: parseInt(chainId),
+            accessList: accessLists[chainId]
+          },
+          signerAddress,
+          null
+        )
+        if (allowed) {
+          return { valid: true, error: '' }
+        }
       }
     }
 

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -186,7 +186,7 @@ export async function checkSingleCredential(
 
     // Check if address is in the list
     const normalizedValues = addressCredential.values.map((v: string) => v.toLowerCase())
-    return normalizedValues.includes(consumerAddress)
+    return normalizedValues.includes(consumerAddress.toLowerCase())
   }
 
   // ========================================


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- handle case in which accessLists from allowedAdmins is empty during signature validation (previously this returned the next error: `Signature check failed: Error during signature validation: TypeError: Cannot convert undefined or null to object`)
- lowercase the consumer address before checking for it in allowed addresses