### PR TITLE
Added defensive null checks for db connection

### DIFF
--- a/src/components/core/handler/policyServer.ts
+++ b/src/components/core/handler/policyServer.ts
@@ -82,7 +82,14 @@ export class PolicyServerInitializeHandler extends CommandHandler {
     }
     // resolve DDO first
     try {
-      const ddo = await this.getOceanNode().getDatabase().ddo.retrieve(task.documentId)
+      const database = this.getOceanNode().getDatabase()
+      if (!database || !database.ddo) {
+        return {
+          stream: null,
+          status: { httpStatus: 503, error: 'DDO database is not available' }
+        }
+      }
+      const ddo = await database.ddo.retrieve(task.documentId)
       if (!ddo) {
         return {
           stream: null,

--- a/src/components/core/handler/queryHandler.ts
+++ b/src/components/core/handler/queryHandler.ts
@@ -20,7 +20,15 @@ export class QueryHandler extends CommandHandler {
       return validationResponse
     }
     try {
-      let result = await this.getOceanNode().getDatabase().ddo.search(task.query)
+      const database = this.getOceanNode().getDatabase()
+      if (!database || !database.ddo) {
+        CORE_LOGGER.error('DDO database is not available')
+        return {
+          stream: null,
+          status: { httpStatus: 503, error: 'DDO database is not available' }
+        }
+      }
+      let result = await database.ddo.search(task.query)
       if (!result) {
         result = []
       }
@@ -45,7 +53,16 @@ export class QueryDdoStateHandler extends QueryHandler {
       return buildInvalidParametersResponse(validation)
     }
     try {
-      const result = await this.getOceanNode().getDatabase().ddoState.search(task.query)
+      const database = this.getOceanNode().getDatabase()
+      if (!database || !database.ddoState) {
+        CORE_LOGGER.error('DDO State database is not available')
+        return {
+          stream: null,
+          status: { httpStatus: 503, error: 'DDO State database is not available' }
+        }
+      }
+
+      const result = await database.ddoState.search(task.query)
 
       CORE_LOGGER.debug(`DDO State search result: ${JSON.stringify(result)}`)
 

--- a/src/components/core/utils/findDdoHandler.ts
+++ b/src/components/core/utils/findDdoHandler.ts
@@ -58,7 +58,17 @@ export async function findDDOLocally(
   node: OceanNode,
   id: string
 ): Promise<FindDDOResponse> | undefined {
-  const ddo = await node.getDatabase().ddo.retrieve(id)
+  const database = node.getDatabase()
+  if (!database || !database.ddo) {
+    CORE_LOGGER.log(
+      LOG_LEVELS_STR.LEVEL_WARN,
+      'DDO database is not available. Cannot retrieve DDO locally.',
+      true
+    )
+    return undefined
+  }
+
+  const ddo = await database.ddo.retrieve(id)
   if (ddo) {
     // node has ddo
     const p2pNode: OceanP2P = node.getP2PNode()

--- a/src/components/core/utils/statusHandler.ts
+++ b/src/components/core/utils/statusHandler.ts
@@ -75,8 +75,15 @@ async function getIndexerBlockInfo(
 ): Promise<string> {
   let blockNr = '0'
   try {
-    const { indexer: indexerDatabase } = oceanNode.getDatabase()
-    const { lastIndexedBlock } = await indexerDatabase.retrieve(supportedNetwork.chainId)
+    const database = oceanNode.getDatabase()
+    if (!database || !database.indexer) {
+      CORE_LOGGER.log(
+        LOG_LEVELS_STR.LEVEL_WARN,
+        `Indexer database is not available for network ${supportedNetwork.network}`
+      )
+      return blockNr
+    }
+    const { lastIndexedBlock } = await database.indexer.retrieve(supportedNetwork.chainId)
     blockNr = lastIndexedBlock.toString()
   } catch (error) {
     CORE_LOGGER.log(

--- a/src/components/httpRoutes/logs.ts
+++ b/src/components/httpRoutes/logs.ts
@@ -74,7 +74,12 @@ logRoutes.post('/logs', express.json(), validateRequest, async (req, res) => {
 logRoutes.post('/log/:id', express.json(), validateRequest, async (req, res) => {
   try {
     const logId = req.params.id
-    const log = await req.oceanNode.getDatabase().logs.retrieveLog(logId)
+    const database = req.oceanNode.getDatabase()
+    if (!database || !database.logs) {
+      res.status(503).send('Logs database is not available')
+      return
+    }
+    const log = await database.logs.retrieveLog(logId)
     if (log) {
       res.json(log)
     } else {


### PR DESCRIPTION
Fixes #1155  .

Changes proposed in this PR:

- This PR adds defensive null/undefined checks around oceanNode.getDatabase() and its sub-stores (ddo, ddoState, logs, indexer) to prevent runtime crashes when the DB layer is not initialized / temporarily unavailable.
- Instead of throwing (e.g. Cannot read properties of undefined), affected API handlers now fail gracefully with 503 Service Unavailable, while internal helpers log a warning and return undefined / default values where appropriate.
