### PR TITLE
set empty array for datasets in case it's missing

### DIFF
--- a/src/components/httpRoutes/compute.ts
+++ b/src/components/httpRoutes/compute.ts
@@ -284,10 +284,14 @@ computeRoutes.post(`${SERVICES_API_BASE_PATH}/initializeCompute`, async (req, re
       res.status(400).send('Missing required body')
       return
     }
-    if (!body.datasets && !body.algorithm) {
-      res.status(400).send('Missing datasets and algorithm')
+
+    body.datasets = body.datasets || []
+
+    if (!body.algorithm) {
+      res.status(400).send('Missing algorithm')
       return
     }
+
     for (const dataset of body.datasets) {
       if (!dataset.documentId) {
         res.status(400).send('Missing dataset did')


### PR DESCRIPTION
Fixes #1091  .

Changes proposed in this PR:

- Allow initializeCompute without datasets