### PR TITLE
imageRetention for build

### DIFF
--- a/src/components/database/C2DDatabase.ts
+++ b/src/components/database/C2DDatabase.ts
@@ -93,6 +93,10 @@ export class C2DDatabase extends AbstractDatabase {
     return await this.provider.updateImage(image)
   }
 
+  async deleteImage(image: string): Promise<void> {
+    return await this.provider.deleteImage(image)
+  }
+
   async getOldImages(retentionDays: number): Promise<string[]> {
     return await this.provider.getOldImages(retentionDays)
   }

--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -165,6 +165,23 @@ export class SQLiteCompute implements ComputeDatabaseProvider {
     })
   }
 
+  deleteImage(image: string): Promise<void> {
+    const deleteSQL = `
+      DELETE FROM docker_images WHERE image = ?;
+    `
+    return new Promise<void>((resolve, reject) => {
+      this.db.run(deleteSQL, [image], (err) => {
+        if (err) {
+          DATABASE_LOGGER.error(`Could not delete image ${image}: ${err.message}`)
+          reject(err)
+        } else {
+          DATABASE_LOGGER.debug(`Deleted image ${image}`)
+          resolve()
+        }
+      })
+    })
+  }
+
   getOldImages(retentionDays: number = 7): Promise<string[]> {
     const cutoffTimestamp = Math.floor(Date.now() / 1000) - retentionDays * 24 * 60 * 60
     const selectSQL = `


### PR DESCRIPTION


Changes proposed in this PR:

- do not delete image built on cleanup, but let them be handled by imageRetetion algo
- add missing deleteImage, so we can delete the record fromdb
- 