### PR TITLE
refactor envs hashing

### DIFF
--- a/src/components/c2d/compute_engine_base.ts
+++ b/src/components/c2d/compute_engine_base.ts
@@ -259,7 +259,12 @@ export abstract class C2DEngine {
   public async getUsedResources(env: ComputeEnvironment): Promise<any> {
     const usedResources: { [x: string]: any } = {}
     const usedFreeResources: { [x: string]: any } = {}
-    const jobs = await this.db.getRunningJobs(this.getC2DConfig().hash)
+    let jobs: DBComputeJob[] = []
+    try {
+      jobs = await this.db.getRunningJobs(this.getC2DConfig().hash)
+    } catch (e) {
+      CORE_LOGGER.error('Failed to get running jobs:' + e.message)
+    }
     let totalJobs = 0
     let totalFreeJobs = 0
     let queuedJobs = 0

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -284,7 +284,7 @@ export class C2DEngineDocker extends C2DEngine {
       }
     }
     this.envs[0].id =
-      this.getC2DConfig().hash + '-' + create256Hash(JSON.stringify(this.envs[0]))
+      this.getC2DConfig().hash + '-' + create256Hash(JSON.stringify(this.envs[0].fees))
 
     // only now set the timer
     if (!this.cronTimer) {
@@ -700,11 +700,10 @@ export class C2DEngineDocker extends C2DEngine {
     if (!this.docker) return []
     const filteredEnvs = []
     // const systemInfo = this.docker ? await this.docker.info() : null
-    for (const computeEnv of this.envs) {
-      if (
-        !chainId ||
-        (computeEnv.fees && Object.hasOwn(computeEnv.fees, String(chainId)))
-      ) {
+    for (const env of this.envs) {
+      if (!chainId || (env.fees && Object.hasOwn(env.fees, String(chainId)))) {
+        const computeEnv = JSON.parse(JSON.stringify(env))
+
         // TO DO - At some point in time we need to handle multiple runtimes
         // console.log('********************************')
         // console.log(systemInfo.GenericResources)
@@ -732,10 +731,12 @@ export class C2DEngineDocker extends C2DEngine {
         computeEnv.queMaxWaitTimeFree = maxWaitTimeFree
         computeEnv.runMaxWaitTime = maxRunningTime
         computeEnv.runMaxWaitTimeFree = maxRunningTimeFree
-        for (let i = 0; i < computeEnv.resources.length; i++) {
-          if (computeEnv.resources[i].id in usedResources)
-            computeEnv.resources[i].inUse = usedResources[computeEnv.resources[i].id]
-          else computeEnv.resources[i].inUse = 0
+        if (computeEnv.resources) {
+          for (let i = 0; i < computeEnv.resources.length; i++) {
+            if (computeEnv.resources[i].id in usedResources)
+              computeEnv.resources[i].inUse = usedResources[computeEnv.resources[i].id]
+            else computeEnv.resources[i].inUse = 0
+          }
         }
         if (computeEnv.free && computeEnv.free.resources) {
           for (let i = 0; i < computeEnv.free.resources.length; i++) {

--- a/src/utils/config/builder.ts
+++ b/src/utils/config/builder.ts
@@ -132,16 +132,17 @@ export function buildC2DClusters(
   dockerComputeEnvironments: C2DDockerConfig[]
 ): C2DClusterInfo[] {
   const clusters: C2DClusterInfo[] = []
-
+  let count = 0
   if (process.env.OPERATOR_SERVICE_URL) {
     try {
       const clustersURLS: string[] = JSON.parse(process.env.OPERATOR_SERVICE_URL)
       for (const theURL of clustersURLS) {
         clusters.push({
           connection: theURL,
-          hash: create256Hash(theURL),
+          hash: create256Hash(String(count) + theURL),
           type: C2DClusterType.OPF_K8
         })
+        count += 1
       }
     } catch (error) {
       CONFIG_LOGGER.error(`Failed to parse OPERATOR_SERVICE_URL: ${error.message}`)
@@ -151,13 +152,14 @@ export function buildC2DClusters(
   if (dockerComputeEnvironments) {
     for (const dockerC2d of dockerComputeEnvironments) {
       if (dockerC2d.socketPath || dockerC2d.host) {
-        const hash = create256Hash(JSON.stringify(dockerC2d))
+        const hash = create256Hash(String(count) + JSON.stringify(dockerC2d))
         clusters.push({
           connection: dockerC2d,
           hash,
           type: C2DClusterType.DOCKER,
           tempFolder: './c2d_storage/' + hash
         })
+        count += 1
       }
     }
   }


### PR DESCRIPTION
# PR: C2D robustness and distinct cluster identity

## Summary

This PR improves C2D compute engine behavior in three areas: (1) cluster hashes are made unique when multiple clusters share the same URL or config, (2) environment IDs are derived only from fees so they stay stable when other env fields change, and (3) `getComputeEnvironments` / `getUsedResources` are hardened against missing data and DB failures.

## Changes

### 1. Config builder – distinct cluster hashes (`src/utils/config/builder.ts`)

- **Problem:** Cluster hash was `create256Hash(theURL)` for operator clusters and `create256Hash(JSON.stringify(dockerC2d))` for Docker clusters. Multiple clusters with the same URL or identical Docker config produced the same hash, which can break anything that uses the hash as a unique cluster id (e.g. job routing, storage paths, env ids).
- **Change:** A running index is included in the hash input:
  - Introduced `let count = 0`.
  - For each operator cluster: `hash = create256Hash(String(count) + theURL)`, then `count += 1`.
  - For each Docker cluster: `hash = create256Hash(String(count) + JSON.stringify(dockerC2d))`, then `count += 1`.
- **Result:** Each cluster gets a distinct hash even when URLs or Docker configs are identical.

### 2. Compute engine Docker – environment ID and `getComputeEnvironments` (`src/components/c2d/compute_engine_docker.ts`)

**Environment ID (env id):**

- **Before:** `this.envs[0].id = hash + '-' + create256Hash(JSON.stringify(this.envs[0]))` — the whole env object was hashed, so any change (e.g. `runningJobs`, `resources`) changed the id.
- **After:** `this.envs[0].id = hash + '-' + create256Hash(JSON.stringify(this.envs[0].fees))` — only `fees` is hashed, so the id is stable across runtime updates and only changes when fee config changes.

**`getComputeEnvironments(chainId?)`:**

- **Filter-then-clone:** The loop now uses `env` from `this.envs` and applies the `chainId` filter first. The deep clone (`JSON.parse(JSON.stringify(env))`) is only created for envs that pass the filter, then used for `getUsedResources` and in-use stats. Avoids mutating `this.envs` and avoids unnecessary clones for filtered-out envs.
- **Optional `resources`:** Iteration over `computeEnv.resources` is wrapped in `if (computeEnv.resources)` so envs with no `resources` (optional in the type) do not throw.

### 3. Compute engine base – `getUsedResources` error handling (`src/components/c2d/compute_engine_base.ts`)

- **Before:** `const jobs = await this.db.getRunningJobs(this.getC2DConfig().hash)` — a DB failure threw and aborted `getUsedResources`, which could take down `getComputeEnvironments` for all envs.
- **After:** `let jobs: DBComputeJob[] = []` with a try/catch around `getRunningJobs`. On failure, the error is logged and `jobs` stays empty, so the method returns zeroed counts and in-use maps instead of throwing.
- **Result:** A transient DB error no longer prevents returning compute environments; callers get envs with zeroed usage instead of a full failure.

## Benefits

- **Stable env ids:** Environment identity no longer changes when job counts or resource usage change; only fee config affects it.
- **Unique cluster hashes:** Multiple clusters with the same URL or Docker config get different hashes, avoiding collisions in storage and routing.
- **Resilience:** DB failures in `getRunningJobs` are logged and isolated; `getComputeEnvironments` can still return envs with zeroed usage.
- **Correctness:** No crash when an env has no `resources`; no mutation of `this.envs` and fewer unnecessary clones when filtering by `chainId`.
