### PR TITLE
fix processor nonce

### DIFF
--- a/src/components/Indexer/processors/BaseProcessor.ts
+++ b/src/components/Indexer/processors/BaseProcessor.ts
@@ -360,7 +360,9 @@ export abstract class BaseEventProcessor {
               .getCoreHandlers()
               .getHandler(PROTOCOL_COMMANDS.NONCE)
               .handle(getNonceTask)
-            nonceP2p = String(parseInt(await streamToString(response.stream as Readable)) + 1)
+            nonceP2p = String(
+              parseInt(await streamToString(response.stream as Readable)) + 1
+            )
           } catch (error) {
             const message = `Node exception on getting nonce from local nodeId ${nodeId}. Status: ${error.message}`
             INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, message)
@@ -423,7 +425,9 @@ export abstract class BaseEventProcessor {
             }
 
             // Convert stream to Uint8Array
-            const remoteNonce = String(parseInt(await streamToString(response.stream as Readable)) + 1)
+            const remoteNonce = String(
+              parseInt(await streamToString(response.stream as Readable)) + 1
+            )
             INDEXER_LOGGER.debug(
               `decryptDDO: Fetched fresh nonce ${remoteNonce} from remote node ${decryptorURL} for decrypt attempt`
             )


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

Root cause: validateNonceAndSignature requires nonce > storedNonce. The HTTP path in the indexer correctly does parseInt(nonce) + 1.It was passing the raw stored nonce without incrementing.