### PR TITLE
fix: claim payments for jobs without jobIdHash

### DIFF
--- a/src/components/database/sqliteCompute.ts
+++ b/src/components/database/sqliteCompute.ts
@@ -6,6 +6,7 @@ import {
 } from '../../@types/C2D/C2D.js'
 import sqlite3, { RunResult } from 'sqlite3'
 import { DATABASE_LOGGER } from '../../utils/logging/common.js'
+import { create256Hash } from '../../utils/crypt.js'
 
 interface ComputeDatabaseProvider {
   newJob(job: DBComputeJob): Promise<string>
@@ -530,6 +531,9 @@ export class SQLiteCompute implements ComputeDatabaseProvider {
               const maxJobDuration = row.expireTimestamp
               delete row.expireTimestamp
               const job: DBComputeJob = { ...row, ...body, maxJobDuration }
+              if (!job.jobIdHash && job.jobId) {
+                job.jobIdHash = create256Hash(job.jobId)
+              }
               return job
             })
             resolve(all)


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- claimPayments flow fails because jobs before 2.1.0 don't have a jobIdHash, error: `Periodic payments claim failed: Cannot convert undefined to a BigInt`