### PR TITLE
enforce policyserver policy if exists

### DIFF
--- a/src/components/core/handler/ddoHandler.ts
+++ b/src/components/core/handler/ddoHandler.ts
@@ -800,7 +800,7 @@ export class ValidateDDOHandler extends CommandHandler {
           task.publisherAddress,
           task.policyServer
         )
-        if (!response) {
+        if (!response.success) {
           CORE_LOGGER.logMessage(
             `Error: Validation for ${task.publisherAddress} was denied`,
             true

--- a/src/components/core/handler/encryptHandler.ts
+++ b/src/components/core/handler/encryptHandler.ts
@@ -71,7 +71,7 @@ export class EncryptHandler extends CommandHandler {
         task.consumerAddress,
         task.policyServer
       )
-      if (!response) {
+      if (!response.success) {
         CORE_LOGGER.logMessage(
           `Error: Encrypt for ${task.consumerAddress} was denied`,
           true
@@ -163,7 +163,7 @@ export class EncryptFileHandler extends CommandHandler {
         task.policyServer,
         task.files
       )
-      if (!response) {
+      if (!response.success) {
         CORE_LOGGER.logMessage(
           `Error: EncryptFile for ${task.consumerAddress} was denied`,
           true

--- a/src/components/policyServer/index.ts
+++ b/src/components/policyServer/index.ts
@@ -5,26 +5,34 @@ import { BaseFileObject } from '../../@types/fileObject.js'
 
 export class PolicyServer {
   serverUrl: string
+  private apikey: string
 
   public constructor() {
     this.serverUrl = process.env.POLICY_SERVER_URL
+    this.apikey = process.env.POLICY_SERVER_API_KEY
   }
 
   private async askServer(command: any): Promise<PolicyServerResult> {
     if (!this.serverUrl) return { success: true, message: '', httpStatus: 404 }
     let response
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    }
+    if (this.apikey) {
+      headers['X-API-Key'] = this.apikey
+    }
     try {
       response = await fetch(this.serverUrl, {
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers,
         method: 'POST',
         body: JSON.stringify(command)
       })
     } catch (e) {
+      const errorText =
+        e instanceof Error ? e.message : typeof e === 'string' ? e : JSON.stringify(e)
       return {
-        success: true,
-        message: '',
+        success: false,
+        message: errorText || 'Policy server request failed',
         httpStatus: 400
       }
     }


### PR DESCRIPTION
# Summary
- Enforce policy-server if exists  (if check fails, reject the action)
- Fix policy-server integration to correctly interpret denial responses via `response.success` (instead of truthiness checks).
- Improve Policy Server client to:
  - Support optional API key header (`POLICY_SERVER_API_KEY` via `X-API-Key`).
  - Return a meaningful error message when the request fails (e.g., network/DNS/connection issues).

