### PR TITLE
fix(#1327): use container finishedAt to compute algo stop time on crash

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -2067,7 +2067,13 @@ export class C2DEngineDocker extends C2DEngine {
             job.isStarted = false
             job.status = C2DStatusNumber.PublishingResults
             job.statusText = C2DStatusText.PublishingResults
-            job.algoStopTimestamp = String(Date.now() / 1000)
+            const containerFinishedAt =
+              new Date(details.State.FinishedAt).getTime() / 1000
+            job.algoStopTimestamp = String(
+              containerFinishedAt > parseFloat(job.algoStartTimestamp)
+                ? containerFinishedAt
+                : Date.now() / 1000
+            )
             job.isRunning = false
             await this.db.updateJob(job)
             return


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- when node crashes, use last container exit time  as algo stop time if available (and past the algo start time) instead of current time 