### PR TITLE
fix: building images on paid jobs when free config is missing

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -1258,7 +1258,7 @@ export class C2DEngineDocker extends C2DEngine {
     if (
       algorithm.meta.container &&
       algorithm.meta.container.dockerfile &&
-      !env.free.allowImageBuild
+      !env.free?.allowImageBuild
     ) {
       throw new Error(`Building image is not allowed for free jobs`)
     }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- currently when container is built (in paid job) for an environment that has no `free` property, the node throws `error: CORE:   Error starting compute job: Cannot read properties of undefined (reading 'allowImageBuild')`