### PR TITLE
fix free env allowimagebuild

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -385,6 +385,8 @@ export class C2DEngineDocker extends C2DEngine {
           env.free.maxJobDuration = envDef.free.maxJobDuration
         if (envDef.free.maxJobs !== undefined) env.free.maxJobs = envDef.free.maxJobs
         if (envDef.free.resources) env.free.resources = envDef.free.resources
+        if (envDef.free.allowImageBuild !== undefined)
+          env.free.allowImageBuild = envDef.free.allowImageBuild
       }
 
       const envIdSuffix = envDef.id || String(envIdx)


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- allowImageBuild never copied from config into runtime env.free
- Free image builds always rejected; field missing from /api/services/computeEnvironments