### PR TITLE
set minjobduration to 0 for benchmark env

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -217,7 +217,7 @@ export class C2DEngineDocker extends C2DEngine {
       description: 'Auto-generated benchmark environment',
       storageExpiry: 604800,
       maxJobDuration: 180,
-      minJobDuration: 60,
+      minJobDuration: 0,
       resources: [
         { id: 'cpu', total: sysinfo.NCPU, min: 1, max: sysinfo.NCPU },
         { id: 'ram', total: ramGB, min: 1, max: ramGB },


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- set minJobDuration to 0 on benchmark env