### PR TITLE
build image log fix

### DIFF
--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -2658,8 +2658,7 @@ export class C2DEngineDocker extends C2DEngine {
     additionalDockerFiles: { [key: string]: any }
   ) {
     const job = JSON.parse(JSON.stringify(originaljob)) as DBComputeJob
-    const imageLogFile =
-      this.getC2DConfig().tempFolder + '/' + job.jobId + '/data/logs/image.log'
+    const imageLogFile = this.getStoragePath() + '/' + job.jobId + '/data/logs/image.log'
     const controller = new AbortController()
     const timeoutMs = job.maxJobDuration * 1000
     const timer = setTimeout(() => controller.abort(), timeoutMs)

--- a/src/test/unit/buildImage.test.ts
+++ b/src/test/unit/buildImage.test.ts
@@ -110,7 +110,9 @@ describe('C2DEngineDocker.buildImage', () => {
     const { engine, db } = await makeEngine({ tempFolder })
 
     const job = makeJob()
-    mkdirSync(path.join(tempFolder, job.jobId, 'data', 'logs'), { recursive: true })
+    mkdirSync(path.join((engine as any).getStoragePath(), job.jobId, 'data', 'logs'), {
+      recursive: true
+    })
 
     const buildStream = new Readable({ read() {} })
     ;(engine as any).docker = {
@@ -135,7 +137,9 @@ describe('C2DEngineDocker.buildImage', () => {
     const { engine, db } = await makeEngine({ tempFolder })
 
     const job = makeJob({ containerImage: 'ocean-node-test:job-123-success' })
-    mkdirSync(path.join(tempFolder, job.jobId, 'data', 'logs'), { recursive: true })
+    mkdirSync(path.join((engine as any).getStoragePath(), job.jobId, 'data', 'logs'), {
+      recursive: true
+    })
 
     const buildStream = new Readable({ read() {} })
     ;(engine as any).docker = {


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

BuildImage builds its log file path from tempFolder instead of getStoragePath() (which is tempFolder + clusterHash). The job folder is created under getStoragePath(), so writes target a non-existent directory.

Fix
 - buildImage: use getStoragePath() for imageLogFile. Aligns with pullImage.
 - buildImage.test.ts: mkdirSync updated to match.