### PR TITLE
fix getDockerMountObject

### DIFF
--- a/src/components/persistentStorage/PersistentStorageFactory.ts
+++ b/src/components/persistentStorage/PersistentStorageFactory.ts
@@ -179,7 +179,7 @@ export abstract class PersistentStorageFactory {
   public abstract getDockerMountObject(
     bucketId: string,
     fileName: string,
-    consumerAddress?: string
+    consumerAddress: string
   ): Promise<DockerMountObject>
 
   public abstract getDockerOutputMountObject(

--- a/src/components/persistentStorage/PersistentStorageLocalFS.ts
+++ b/src/components/persistentStorage/PersistentStorageLocalFS.ts
@@ -208,7 +208,7 @@ export class PersistentStorageLocalFS extends PersistentStorageFactory {
   async getDockerMountObject(
     bucketId: string,
     fileName: string,
-    consumerAddress?: string
+    consumerAddress: string
   ): Promise<DockerMountObject> {
     await this.ensureBucketExists(bucketId)
     if (!consumerAddress) {

--- a/src/components/persistentStorage/PersistentStorageS3.ts
+++ b/src/components/persistentStorage/PersistentStorageS3.ts
@@ -80,7 +80,7 @@ export class PersistentStorageS3 extends PersistentStorageFactory {
   async getDockerMountObject(
     _bucketId: string,
     _fileName: string,
-    _consumerAddress?: string
+    _consumerAddress: string
   ): Promise<DockerMountObject> {
     throw new Error('PersistentStorageS3 is not implemented yet')
   }

--- a/src/test/integration/persistentStorage.test.ts
+++ b/src/test/integration/persistentStorage.test.ts
@@ -166,7 +166,7 @@ describe('**********         Persistent storage handlers (integration)', functio
         ownerAddress
       )
 
-      const mount = await backend.getDockerMountObject(bucketId, fileName)
+      const mount = await backend.getDockerMountObject(bucketId, fileName, ownerAddress)
       expect(path.isAbsolute(mount.Source)).to.equal(true)
     } finally {
       await fsp.rm(path.resolve(relativeFolder), { recursive: true, force: true })


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- 
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The consumer address parameter is now required when requesting storage mount objects. Previously optional, this parameter must now be explicitly provided by all callers to ensure proper access validation and resource isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->