### PR TITLE
refactor: update Elasticsearch and Typesense db index upsert

### DIFF
--- a/src/components/database/ElasticSearchDatabase.ts
+++ b/src/components/database/ElasticSearchDatabase.ts
@@ -778,12 +778,10 @@ export class ElasticsearchDdoDatabase extends AbstractDdoDatabase {
       if (ddo?.indexedMetadata?.nft) delete ddo.nft
       const validation = await validateDDO(ddo)
       if (validation === true) {
-        const response: any = await this.client.update({
+        const response: any = await this.client.index({
           index: schema.index,
           id: ddo.id,
-          body: {
-            doc: ddo
-          }
+          body: ddo
         })
         // make sure we do not have different responses 4 between DBs
         // do the same thing on other methods

--- a/src/components/database/ElasticSearchDatabase.ts
+++ b/src/components/database/ElasticSearchDatabase.ts
@@ -633,6 +633,33 @@ export class ElasticsearchDdoDatabase extends AbstractDdoDatabase {
     return schema
   }
 
+  private async deleteDDOFromOtherSchemas(
+    id: string,
+    currentSchema: ElasticsearchSchema
+  ): Promise<void> {
+    for (const schema of this.getSchemas()) {
+      if (schema.index === currentSchema.index) {
+        continue
+      }
+
+      try {
+        await this.client.delete({
+          index: schema.index,
+          id
+        })
+      } catch (error) {
+        if (error.statusCode !== 404) {
+          DATABASE_LOGGER.logMessageWithEmoji(
+            `Error when deleting stale DDO entry ${id} from schema ${schema.index}: ${error.message}`,
+            true,
+            GENERIC_EMOJIS.EMOJI_CROSS_MARK,
+            LOG_LEVELS_STR.LEVEL_ERROR
+          )
+        }
+      }
+    }
+  }
+
   async search(query: Record<string, any>): Promise<any> {
     const results = []
     const maxPerPage = query.size || 100
@@ -783,6 +810,7 @@ export class ElasticsearchDdoDatabase extends AbstractDdoDatabase {
           id: ddo.id,
           body: ddo
         })
+        await this.deleteDDOFromOtherSchemas(ddo.id, schema)
         // make sure we do not have different responses 4 between DBs
         // do the same thing on other methods
         if (response._id === ddo.id) {

--- a/src/components/database/TypesenseDatabase.ts
+++ b/src/components/database/TypesenseDatabase.ts
@@ -643,10 +643,7 @@ export class TypesenseDdoDatabase extends AbstractDdoDatabase {
       if (ddo?.indexedMetadata?.nft) delete ddo.nft
       const validation = await validateDDO(ddo)
       if (validation === true) {
-        return await this.provider
-          .collections(schema.name)
-          .documents()
-          .update(ddo.id, ddo)
+        return await this.provider.collections(schema.name).documents().upsert(ddo)
       } else {
         throw new Error(
           `Validation of DDO with schema version ${ddo.version} failed with errors`

--- a/src/components/database/TypesenseDatabase.ts
+++ b/src/components/database/TypesenseDatabase.ts
@@ -521,6 +521,31 @@ export class TypesenseDdoDatabase extends AbstractDdoDatabase {
     return schema
   }
 
+  private async deleteDDOFromOtherSchemas(
+    did: string,
+    currentSchema: TypesenseSchema
+  ): Promise<void> {
+    for (const schema of this.getSchemas()) {
+      if (schema.name === currentSchema.name) {
+        continue
+      }
+
+      try {
+        await this.provider.collections(schema.name).documents().delete(did)
+      } catch (error) {
+        if (!(error instanceof TypesenseError && error.httpStatus === 404)) {
+          DATABASE_LOGGER.logMessageWithEmoji(
+            `Error when deleting stale DDO entry ${did} from schema ${schema.name}: ` +
+              error.message,
+            true,
+            GENERIC_EMOJIS.EMOJI_CROSS_MARK,
+            LOG_LEVELS_STR.LEVEL_ERROR
+          )
+        }
+      }
+    }
+  }
+
   async search(
     query: Record<string, any>,
     maxResultsPerPage?: number,
@@ -643,7 +668,12 @@ export class TypesenseDdoDatabase extends AbstractDdoDatabase {
       if (ddo?.indexedMetadata?.nft) delete ddo.nft
       const validation = await validateDDO(ddo)
       if (validation === true) {
-        return await this.provider.collections(schema.name).documents().upsert(ddo)
+        const response = await this.provider
+          .collections(schema.name)
+          .documents()
+          .upsert(ddo)
+        await this.deleteDDOFromOtherSchemas(ddo.id, schema)
+        return response
       } else {
         throw new Error(
           `Validation of DDO with schema version ${ddo.version} failed with errors`

--- a/src/components/database/typesense.ts
+++ b/src/components/database/typesense.ts
@@ -59,6 +59,14 @@ class TypesenseDocuments {
   }
 
   // eslint-disable-next-line require-await
+  async upsert(document: TypesenseDocumentSchema) {
+    if (!document) throw new Error('No document provided')
+    return this.api.post<TypesenseDocumentSchema>(this.apiPath, document, {
+      action: 'upsert'
+    })
+  }
+
+  // eslint-disable-next-line require-await
   async retrieve(documentId: string) {
     const path = `${this.apiPath}/${documentId}`
     return this.api.get<TypesenseDocumentSchema>(path)


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

update Elasticsearch and Typesense database methods for document indexing and upserting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DDO persistence: Elasticsearch updates now re-index the full document to replace existing records more reliably.
  * Improved DDO persistence: Typesense updates now use upsert to create or replace documents consistently.
  * After successful writes, stale copies of the same DDO id are removed from other configured schemas across search backends.
  * Kept existing validation and fallback behavior for error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->