### PR TITLE
bump contract to 2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-node --with-typesense 2>&1 > start_ocean.log &
+        env:
+          CONTRACTS_VERSION: '2.9.0'
       - run: npm ci
       - run: npm run build
       - run: docker image ls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,8 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-node --with-typesense 2>&1 > start_ocean.log &
+        env:
+          CONTRACTS_VERSION: '2.9.0'
       - run: docker image ls
       - name: Delete default runner images
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@libp2p/upnp-nat": "^4.0.9",
         "@libp2p/websockets": "^10.1.2",
         "@multiformats/multiaddr": "^12.2.3",
-        "@oceanprotocol/contracts": "^2.7.0",
+        "@oceanprotocol/contracts": "^2.9.0",
         "@oceanprotocol/ddo-js": "^0.4.0",
         "axios": "^1.15.0",
         "base58-js": "^2.0.0",
@@ -5237,9 +5237,9 @@
       }
     },
     "node_modules/@oceanprotocol/contracts": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.7.0.tgz",
-      "integrity": "sha512-6rXT/agjty4VyT0j/Do13Rf8dH0eweL57e7rFSv4KmANFx3wdTcQoInHZsoRpwXZf1MmMgHVWL4/ZvqHtRqMRA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.9.0.tgz",
+      "integrity": "sha512-B3dQNxIYD7bASNE066vfZu6Ik5uHZ/1c+QEcUvAsfoNvUUJ5+uQfIvhwrpdMCza1GtE11EW2glDPZvbr2LwFsg==",
       "license": "Apache-2.0"
     },
     "node_modules/@oceanprotocol/ddo-js": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@libp2p/upnp-nat": "^4.0.9",
     "@libp2p/websockets": "^10.1.2",
     "@multiformats/multiaddr": "^12.2.3",
-    "@oceanprotocol/contracts": "^2.7.0",
+    "@oceanprotocol/contracts": "^2.9.0",
     "@oceanprotocol/ddo-js": "^0.4.0",
     "axios": "^1.15.0",
     "base58-js": "^2.0.0",

--- a/src/@types/Escrow.ts
+++ b/src/@types/Escrow.ts
@@ -32,4 +32,7 @@ export interface EscrowEvent {
   maxLockedAmount?: string
   maxLockSeconds?: string
   maxLockCounts?: string
+  oldAmount?: string
+  newAmount?: string
+  newExpiry?: string
 }

--- a/src/components/Indexer/processor.ts
+++ b/src/components/Indexer/processor.ts
@@ -46,6 +46,7 @@ const EVENT_PROCESSOR_MAP: Record<string, ProcessorConstructor> = {
   [EVENTS.ADDRESS_REMOVED]: AddressRemovedEventProcessor,
   [EVENTS.ESCROW_AUTH]: EscrowEventProcessor,
   [EVENTS.ESCROW_LOCK]: EscrowEventProcessor,
+  [EVENTS.ESCROW_RELOCK]: EscrowEventProcessor,
   [EVENTS.ESCROW_CLAIMED]: EscrowEventProcessor,
   [EVENTS.ESCROW_CANCELED]: EscrowEventProcessor,
   [EVENTS.ESCROW_DEPOSIT]: EscrowEventProcessor,

--- a/src/components/Indexer/processors/EscrowEventProcessor.ts
+++ b/src/components/Indexer/processors/EscrowEventProcessor.ts
@@ -57,6 +57,7 @@ export class EscrowEventProcessor extends BaseEventProcessor {
         case EVENTS.ESCROW_AUTH:
           record.payer = addr(args.payer)
           record.payee = addr(args.payee)
+          record.token = addr(args.token)
           record.maxLockedAmount = num(args.maxLockedAmount)
           record.maxLockSeconds = num(args.maxLockSeconds)
           record.maxLockCounts = num(args.maxLockCounts)
@@ -67,6 +68,15 @@ export class EscrowEventProcessor extends BaseEventProcessor {
           record.jobId = num(args.jobId)
           record.amount = num(args.amount)
           record.expiry = num(args.expiry)
+          record.token = addr(args.token)
+          break
+        case EVENTS.ESCROW_RELOCK:
+          record.payer = addr(args.payer)
+          record.payee = addr(args.payee)
+          record.jobId = num(args.jobId)
+          record.oldAmount = num(args.oldAmount)
+          record.newAmount = num(args.newAmount)
+          record.newExpiry = num(args.newExpiry)
           record.token = addr(args.token)
           break
         case EVENTS.ESCROW_CLAIMED:

--- a/src/components/database/ElasticSchemas.ts
+++ b/src/components/database/ElasticSchemas.ts
@@ -165,7 +165,10 @@ export const elasticSchemas: ElasticsearchSchemas = {
           proof: { type: 'text' },
           maxLockedAmount: { type: 'text' },
           maxLockSeconds: { type: 'text' },
-          maxLockCounts: { type: 'text' }
+          maxLockCounts: { type: 'text' },
+          oldAmount: { type: 'text' },
+          newAmount: { type: 'text' },
+          newExpiry: { type: 'text' }
         }
       }
     }

--- a/src/components/database/TypesenseSchemas.ts
+++ b/src/components/database/TypesenseSchemas.ts
@@ -166,7 +166,11 @@ export const typesenseSchemas: TypesenseSchemas = {
       { name: 'proof', type: 'string', optional: true, index: false },
       { name: 'maxLockedAmount', type: 'string', optional: true },
       { name: 'maxLockSeconds', type: 'string', optional: true },
-      { name: 'maxLockCounts', type: 'string', optional: true }
+      { name: 'maxLockCounts', type: 'string', optional: true },
+      // ReLock event fields (uint256 kept as raw strings)
+      { name: 'oldAmount', type: 'string', optional: true },
+      { name: 'newAmount', type: 'string', optional: true },
+      { name: 'newExpiry', type: 'string', optional: true }
     ]
   }
 }

--- a/src/test/integration/escrow.test.ts
+++ b/src/test/integration/escrow.test.ts
@@ -196,6 +196,7 @@ describe('Indexer stores Escrow contract events', () => {
     const event = events[0]
     expect(event.payer).to.equal(payerAddress.toLowerCase())
     expect(event.payee).to.equal(payeeAddress.toLowerCase())
+    expect(event.token).to.equal(paymentToken.toLowerCase())
     expect(event.maxLockedAmount).to.equal(depositAmount.toString())
     expect(event.maxLockCounts).to.equal('10')
   })
@@ -223,6 +224,39 @@ describe('Indexer stores Escrow contract events', () => {
     expect(event.token).to.equal(paymentToken.toLowerCase())
   })
 
+  it('indexes a ReLock event', async function () {
+    if (!escrowAddress || !paymentToken) this.skip()
+    this.timeout(DEFAULT_TEST_TIMEOUT * 3)
+
+    // reLock adjusts the amount/expiry of the lock created in the previous test
+    // for the same jobId, preserving the original creation timestamp. The new
+    // expiry is a duration-from-now capped by (creationTimestamp + maxLockSeconds),
+    // so use a value well below `expiry` (== maxLockSeconds) to leave headroom for
+    // the wall-clock time spent waiting on the Lock event to be indexed above.
+    const newLockAmount = parseUnits('20', 18)
+    const reLockExpiry = Math.floor(expiry / 2)
+    const tx = await escrowContract
+      .connect(publisherAccount)
+      .reLock(jobId, paymentToken, payerAddress, newLockAmount, reLockExpiry)
+    const receipt = await tx.wait()
+    const reLockTxHash = receipt.hash
+
+    const events = await waitForEscrowEvents({
+      txHash: reLockTxHash,
+      eventType: EVENTS.ESCROW_RELOCK
+    })
+    assert(events && events.length > 0, 'ReLock event should be indexed')
+    const event = events[0]
+    expect(event.payer).to.equal(payerAddress.toLowerCase())
+    expect(event.payee).to.equal(payeeAddress.toLowerCase())
+    expect(event.jobId).to.equal(jobId.toString())
+    expect(event.oldAmount).to.equal(lockAmount.toString())
+    expect(event.newAmount).to.equal(newLockAmount.toString())
+    expect(event.token).to.equal(paymentToken.toLowerCase())
+    // expiry is emitted as an absolute timestamp; just assert it is populated
+    assert(event.newExpiry, 'newExpiry should be populated')
+  })
+
   it('returns indexed events through the EscrowEventsHandler (query command)', async function () {
     if (!escrowAddress || !paymentToken) this.skip()
     this.timeout(DEFAULT_TEST_TIMEOUT)
@@ -246,7 +280,7 @@ describe('Indexer stores Escrow contract events', () => {
 
   it('respects offset and size pagination', async function () {
     if (!escrowAddress || !paymentToken) this.skip()
-    // Deposit, Auth and Lock are all indexed for this chain by now (>= 2 rows).
+    // Deposit, Auth, Lock and ReLock are all indexed for this chain by now (>= 2 rows).
     const page = await database.escrow.search({ chainId }, 0, 2)
     assert(page && page.length === 2, 'size should cap the page to 2 rows')
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -132,6 +132,7 @@ export const EVENTS = {
   // Escrow contract events. Values must equal the on-chain event name.
   ESCROW_AUTH: 'Auth',
   ESCROW_LOCK: 'Lock',
+  ESCROW_RELOCK: 'ReLock',
   ESCROW_CLAIMED: 'Claimed',
   ESCROW_CANCELED: 'Canceled',
   ESCROW_DEPOSIT: 'Deposit',
@@ -141,6 +142,7 @@ export const EVENTS = {
 export const ESCROW_EVENTS = [
   EVENTS.ESCROW_AUTH,
   EVENTS.ESCROW_LOCK,
+  EVENTS.ESCROW_RELOCK,
   EVENTS.ESCROW_CLAIMED,
   EVENTS.ESCROW_CANCELED,
   EVENTS.ESCROW_DEPOSIT,
@@ -227,13 +229,17 @@ export const EVENT_HASHES: Hashes = {
     type: EVENTS.NEW_ACCESS_LIST,
     text: 'NewAccessList(address,address)'
   },
-  '0x118cb6c6a02e26bfdb39cab8d70573499942c4ee3f0d7616d3c4100fe9163d9d': {
+  '0x5a3021f46552b1ac3c96e967ff1ecfeb100603ccc2940941cad97db3ee2baec7': {
     type: EVENTS.ESCROW_AUTH,
-    text: 'Auth(address,address,uint256,uint256,uint256)'
+    text: 'Auth(address,address,address,uint256,uint256,uint256)'
   },
   '0xb746b0421b0b98debe76bb312ec9fb701603af22ddb107f7e639b0187e4ff880': {
     type: EVENTS.ESCROW_LOCK,
     text: 'Lock(address,address,uint256,uint256,uint256,address)'
+  },
+  '0x1ccec59cf72b2788d240da471a5a929af5babf4b9f1f5edafbe4ccb832d20211': {
+    type: EVENTS.ESCROW_RELOCK,
+    text: 'ReLock(address,address,uint256,uint256,uint256,uint256,address)'
   },
   '0x77aeb72af8b0efaf7fd8c746d2fb78653ae489dd88dea7a851cb354e4cdc4eed': {
     type: EVENTS.ESCROW_CLAIMED,


### PR DESCRIPTION
## Integrate @oceanprotocol/contracts 2.9.0 — Escrow `Auth` + `ReLock` events

### Summary

Updates the indexer to the Escrow contract shipped in `@oceanprotocol/contracts@2.9.0`
([contracts#1031](https://github.com/oceanprotocol/contracts/pull/1031), "add bundles &
relocks"). Two indexer-relevant changes landed on-chain:

- The **`Auth`** event gained a non-indexed `address token` (between `payee` and
  `maxLockedAmount`), so indexers no longer have to infer which token an authorization
  applies to.
- A **new `ReLock`** event is emitted when a payee adjusts an active lock's amount/expiry.

This PR wires both into the existing Escrow indexing pipeline. It does **not** adopt the new
bundle entrypoints (`bundle`, `bundleJobs`) or call `reLock`/`reLocks` from the node — we only
index the events.

### Why the code change is needed

The indexer matches logs against a **hardcoded** `EVENT_HASHES` table (topic0 → signature),
used both as the `getLogs` topic filter and for dispatch. Because the `Auth` signature changed,
its keccak256 topic0 changed too — the stale entry meant new-format `Auth` logs would be
neither fetched nor dispatched. `ReLock` had no entry at all. The ABI decode path itself needs
no change: `EscrowEventProcessor` builds its `Interface` from the imported 2.9.0 artifact.

### What's included

| Area | Change |
| --- | --- |
| `src/utils/constants.ts` | `Auth` topic0 → `0x5a3021f4…`, signature → `Auth(address,address,address,uint256,uint256,uint256)`; added `ESCROW_RELOCK` to `EVENTS`, `ESCROW_EVENTS`, and `EVENT_HASHES` (`0x1ccec59c…`) |
| `src/components/Indexer/processor.ts` | Registered `ReLock` → `EscrowEventProcessor` in `EVENT_PROCESSOR_MAP` |
| `src/components/Indexer/processors/EscrowEventProcessor.ts` | Store `token` on the `Auth` case; added the `ReLock` case (`payer`, `payee`, `jobId`, `oldAmount`, `newAmount`, `newExpiry`, `token`) |
| `src/@types/Escrow.ts` | Added `oldAmount?`, `newAmount?`, `newExpiry?` to `EscrowEvent` |
| `src/components/database/{Typesense,Elastic}Schemas.ts` | Declared the three new fields on the `escrow` schema (uint256 kept as raw strings) |
| `package.json` | Bumped `@oceanprotocol/contracts` to 2.9.0 |

The `Auth` `token` reuses the existing `EscrowEvent.token` field, and the query/read path
(`GetEscrowEventsCommand`, `EscrowEventsHandler`, the `escrow` HTTP route) needs no change —
`eventType: 'ReLock'` is accepted because `ReLock` is now in `ESCROW_EVENTS`. The other five
Escrow events (Deposit/Lock/Claimed/Canceled/Withdraw) are unchanged; their topic0s already
match the 2.9.0 ABI.

### Tests

- `src/test/integration/escrow.test.ts`: the `Auth` test now also asserts the indexed `token`,
  and a new `indexes a ReLock event` test creates a lock then `reLock`s it and asserts the
  indexed `payer`/`payee`/`jobId`/`oldAmount`/`newAmount`/`token` (and that `newExpiry` is
  populated).
- Verified end-to-end against Barge running the contracts: **7/7 escrow integration tests
  pass** on both Typesense and Elasticsearch backends. `type-check` and `lint` are clean.

> Note: `reLock`'s expiry is a duration-from-now capped by `creationTimestamp + maxLockSeconds`,
> so the ReLock test passes a value below `maxLockSeconds` to leave headroom for the wall-clock
> time spent waiting on the Lock event to index.
