### PR TITLE
fix hardcoded event

### DIFF
--- a/src/components/core/handler/ddoHandler.ts
+++ b/src/components/core/handler/ddoHandler.ts
@@ -12,7 +12,12 @@ import {
 } from '../utils/findDdoHandler.js'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { GENERIC_EMOJIS, LOG_LEVELS_STR } from '../../../utils/logging/Logger.js'
-import { sleep, readStream, streamToUint8Array } from '../../../utils/util.js'
+import {
+  sleep,
+  readStream,
+  streamToUint8Array,
+  fetchEventFromTransaction
+} from '../../../utils/util.js'
 import { CORE_LOGGER } from '../../../utils/logging/common.js'
 import { ethers, isAddress } from 'ethers'
 import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json' with { type: 'json' }
@@ -47,6 +52,26 @@ const MAX_NUM_PROVIDERS = 5
 const MAX_RESPONSE_WAIT_TIME_SECONDS = 60
 // wait time for reading the next getDDO command
 const MAX_WAIT_TIME_SECONDS_GET_DDO = 5
+
+// scans all receipt logs for a MetadataCreated/MetadataUpdated event emitted by the
+// given data NFT. The metadata event is not necessarily the first log of the
+// transaction (AA accounts, multisigs and relayers emit other events before it)
+export function findMetadataEventInLogs(
+  logs: readonly { address: string; topics: readonly string[]; data: string }[],
+  dataNftAddress: string
+): ethers.LogDescription | null {
+  const abiInterface = new ethers.Interface(ERC721Template.abi)
+  const nftLogs = logs.filter(
+    (log) => log.address.toLowerCase() === dataNftAddress.toLowerCase()
+  )
+  for (const eventName of [EVENTS.METADATA_CREATED, EVENTS.METADATA_UPDATED]) {
+    const events = fetchEventFromTransaction({ logs: nftLogs }, eventName, abiInterface)
+    if (events && events.length > 0) {
+      return events[0]
+    }
+  }
+  return null
+}
 
 export class DecryptDdoHandler extends CommandHandler {
   validate(command: DecryptDDOCommand): ValidateParams {
@@ -211,20 +236,14 @@ export class DecryptDdoHandler extends CommandHandler {
       if (transactionId) {
         try {
           const receipt = await provider.getTransactionReceipt(transactionId)
-          if (!receipt.logs.length) {
+          if (!receipt || !receipt.logs.length) {
             throw new Error('receipt logs 0')
           }
-          const abiInterface = new ethers.Interface(ERC721Template.abi)
-          const eventObject = {
-            topics: receipt.logs[0].topics as string[],
-            data: receipt.logs[0].data
-          }
-          const eventData = abiInterface.parseLog(eventObject)
-          if (
-            eventData.name !== EVENTS.METADATA_CREATED &&
-            eventData.name !== EVENTS.METADATA_UPDATED
-          ) {
-            throw new Error(`event name ${eventData.name}`)
+          const eventData = findMetadataEventInLogs(receipt.logs, dataNftAddress)
+          if (!eventData) {
+            throw new Error(
+              `transaction ${transactionId} does not contain a MetadataCreated or MetadataUpdated event emitted by ${dataNftAddress}`
+            )
           }
           flags = parseInt(eventData.args[3], 16)
           encryptedDocument = ethers.getBytes(eventData.args[4])

--- a/src/test/unit/ddoEventLog.test.ts
+++ b/src/test/unit/ddoEventLog.test.ts
@@ -1,0 +1,94 @@
+import { expect } from 'chai'
+import { ethers } from 'ethers'
+import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC721Template.sol/ERC721Template.json' with { type: 'json' }
+import { findMetadataEventInLogs } from '../../components/core/handler/ddoHandler.js'
+import { EVENTS } from '../../utils/constants.js'
+
+describe('findMetadataEventInLogs', () => {
+  const nftAddress = '0x0d4Aa8DfDdBE0c4B4d5DF981f5416fd6001CE1e8'
+  const otherNftAddress = '0x2473f4F7bf40ed0310eEf9f3b52A9c15dbC1DCbc'
+  const publisherAddress = '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260'
+  const abiInterface = new ethers.Interface(ERC721Template.abi)
+
+  const flags = '0x02'
+  const encryptedData = '0x1234567890abcdef'
+  const metaDataHash = ethers.id('some metadata')
+
+  function buildMetadataLog(eventName: string, emitter: string) {
+    const { topics, data } = abiInterface.encodeEventLog(eventName, [
+      publisherAddress,
+      0,
+      'http://localhost:8000',
+      flags,
+      encryptedData,
+      metaDataHash,
+      1735689600,
+      100
+    ])
+    return { address: emitter, topics, data }
+  }
+
+  // an unrelated event emitted before the metadata one (e.g. by an ERC-4337
+  // entry point, a multisig wallet or an ERC20 token)
+  function buildForeignLog(emitter: string) {
+    return {
+      address: emitter,
+      topics: [
+        ethers.id('Transfer(address,address,uint256)'),
+        ethers.zeroPadValue(publisherAddress, 32),
+        ethers.zeroPadValue(otherNftAddress, 32)
+      ],
+      data: ethers.zeroPadValue('0x01', 32)
+    }
+  }
+
+  it('should find MetadataCreated when it is not the first log in the receipt', () => {
+    const logs = [
+      buildForeignLog('0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'),
+      buildForeignLog(otherNftAddress),
+      buildMetadataLog(EVENTS.METADATA_CREATED, nftAddress)
+    ]
+    const eventData = findMetadataEventInLogs(logs, nftAddress)
+    expect(eventData).to.not.equal(null)
+    expect(eventData.name).to.equal(EVENTS.METADATA_CREATED)
+    expect(parseInt(eventData.args[3], 16)).to.equal(2)
+    expect(eventData.args[4]).to.equal(encryptedData)
+    expect(eventData.args[5]).to.equal(metaDataHash)
+  })
+
+  it('should find MetadataUpdated as well', () => {
+    const logs = [
+      buildForeignLog(otherNftAddress),
+      buildMetadataLog(EVENTS.METADATA_UPDATED, nftAddress)
+    ]
+    const eventData = findMetadataEventInLogs(logs, nftAddress)
+    expect(eventData).to.not.equal(null)
+    expect(eventData.name).to.equal(EVENTS.METADATA_UPDATED)
+  })
+
+  it('should match the data NFT address case-insensitively', () => {
+    const logs = [buildMetadataLog(EVENTS.METADATA_CREATED, nftAddress.toLowerCase())]
+    const eventData = findMetadataEventInLogs(logs, nftAddress)
+    expect(eventData).to.not.equal(null)
+    expect(eventData.name).to.equal(EVENTS.METADATA_CREATED)
+  })
+
+  it('should ignore metadata events emitted by other contracts', () => {
+    const logs = [
+      buildMetadataLog(EVENTS.METADATA_CREATED, otherNftAddress),
+      buildMetadataLog(EVENTS.METADATA_UPDATED, nftAddress)
+    ]
+    const eventData = findMetadataEventInLogs(logs, nftAddress)
+    expect(eventData).to.not.equal(null)
+    expect(eventData.name).to.equal(EVENTS.METADATA_UPDATED)
+  })
+
+  it('should return null when the transaction has no metadata event', () => {
+    const logs = [buildForeignLog(nftAddress), buildForeignLog(otherNftAddress)]
+    expect(findMetadataEventInLogs(logs, nftAddress)).to.equal(null)
+  })
+
+  it('should return null for an empty logs array', () => {
+    expect(findMetadataEventInLogs([], nftAddress)).to.equal(null)
+  })
+})


### PR DESCRIPTION
# Fix: don't assume the metadata event is the first log in the transaction

### Summary

`DecryptDdoHandler.decryptDDO()` resolved the encrypted document from a `transactionId` by
parsing **`receipt.logs[0]`** and requiring it to be `MetadataCreated`/`MetadataUpdated`.
That assumption only holds for plain EOA transactions. For transactions sent through
**account-abstraction wallets (ERC-4337), multisigs (e.g. Safe) or relayers**, other events
(EntryPoint/wallet/token events) precede the metadata event, so decryption failed with
`Decrypt DDO: Failed to process transaction id` even though the transaction contains a
perfectly valid metadata event.

### What changed

- New helper `findMetadataEventInLogs(logs, dataNftAddress)` in
  `src/components/core/handler/ddoHandler.ts`:
  - scans **all** receipt logs instead of only `logs[0]`,
  - only considers logs **emitted by the data NFT contract itself** (case-insensitive
    address match) — so batched AA transactions that touch multiple NFTs resolve the event
    of the correct contract,
  - reuses the existing `fetchEventFromTransaction()` util from `src/utils/util.ts` for the
    actual log parsing/matching (no shared-util changes needed; logs are pre-filtered by
    NFT address before delegating),
  - returns the parsed `MetadataCreated` or `MetadataUpdated` event, or `null`.
- `decryptDDO()` now uses the helper; also guards against a `null` receipt. Arg extraction
  (`args[3]`/`args[4]`/`args[5]` = flags / encrypted document / document hash) and the
  error contract (HTTP 400 `Failed to process transaction id`, specific reason logged) are
  unchanged.

Note: `getEventFromTx()` from `src/utils/util.ts` could **not** be reused here — it matches
on `log.fragment.name`, which is only populated on receipts obtained from an ethers
`Contract` (`tx.wait()`). `provider.getTransactionReceipt()` returns plain logs without
`fragment`, so it would never match.

### Audit: other hard-coded event positions in the codebase

The rest of the codebase was audited for the same class of bug:

- `src/components/Indexer/ChainIndexer.ts` (`receipt.logs[reindexTask.eventIndex]`) —
  numeric index, but `eventIndex` is optional, never set by its only producer
  (`reindexTxHandler`), and falls back to scanning all logs when undefined. Intentional
  targeted-reindex feature; left as is.
- Everything else is already position-independent: `getEventFromTx` /
  `fetchEventFromTransaction` filter all logs; `BaseProcessor.getEventData` and the main
  indexer loop match `topics[0]` event-signature hashes across all logs; remaining
  `topics[N]` usages are standard indexed-argument access.

### Tests

- New unit suite `src/test/unit/ddoEventLog.test.ts` (6 tests) using synthetic receipts
  built with `Interface.encodeEventLog`:
  - finds `MetadataCreated` when it is **not** the first log (the AA/multisig scenario),
  - finds `MetadataUpdated`,
  - matches the NFT address case-insensitively,
  - ignores metadata events emitted by **other** contracts in the same transaction,
  - returns `null` when no metadata event exists / on an empty logs array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of metadata events in transaction logs, making decrypt-related flows more reliable.
  * Better handles transactions with multiple logs, different event types, or events emitted from matching contract addresses.
  * Added clearer failures when transaction receipts are missing logs or no relevant metadata event is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->