### PR TITLE
fix network recreate

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -68,6 +68,22 @@ cpu/ram/gpu allocation and keeps its host ports held — until it is restarted, 
 stopped, or swept by the same expiry check once `expiresAt` passes (which then fully releases
 everything, same as a normal expiry).
 
+**Restart is self-healing with respect to leftover Docker state.** Each service gets a Docker
+network with the deterministic name `ocean-svc-<serviceId>`. Teardown (restart, stop, expiry
+sweep) removes that network by name — not just by the stored network id — force-removing any
+stale attached container first, so state leaked by a node crash mid-start cannot wedge the
+service. If network creation still hits a name conflict, the stale network is removed and
+creation is retried once.
+
+A leftover network is deliberately **removed and recreated rather than reused**. Reusing it
+would save nothing: a leaked network can still have a stale container attached (crashed after
+`container.start()` but before the job record was persisted), still bound to the service's
+host ports — so the old container must be inspected and force-removed either way, and at that
+point recreating the now-empty network is a single cheap API call. Recreating also guarantees
+the network always reflects the current code's configuration instead of silently inheriting
+whatever options a previous node version created it with, and it matches restart's overall
+tear-down-and-rebuild semantics (the container is never reused either).
+
 ## Configuration
 
 Service-on-demand is configured per Docker connection under `serviceOnDemand`:

--- a/src/components/c2d/compute_engine_docker.ts
+++ b/src/components/c2d/compute_engine_docker.ts
@@ -85,6 +85,10 @@ const C2D_CONTAINER_GID = 1000
 
 const trivyImage = 'aquasec/trivy:0.69.3' // Use pinned versions for safety
 
+// "Already gone" Docker errors (404 missing, 304 already stopped) are the desired end
+// state of a teardown, so treat them as success.
+const isBenignDockerError = (e: any) => e?.statusCode === 404 || e?.statusCode === 304
+
 export class C2DEngineDocker extends C2DEngine {
   private envs: ComputeEnvironment[] = []
 
@@ -3294,11 +3298,7 @@ export class C2DEngineDocker extends C2DEngine {
           null,
           serviceId
         )
-      if (job.networkId)
-        await this.docker
-          .getNetwork(job.networkId)
-          .remove()
-          .catch(() => {})
+      await this.removeServiceNetwork(serviceId, job.networkId).catch(() => {})
       for (const ep of job.endpoints) releaseHostPort(ep.hostPort)
       job.status = ServiceStatusNumber.Error
       job.statusText = 'Service start aborted (node restarted mid-start)'
@@ -3425,7 +3425,7 @@ export class C2DEngineDocker extends C2DEngine {
         url: `http://${nodeHost}:${hostPorts[i]}`
       }))
 
-      network = await this.docker.createNetwork({ Name: `ocean-svc-${serviceId}` })
+      network = await this.createServiceNetwork(serviceId)
 
       // Container env from the decrypted (in-memory) userData; command/entrypoint from the request.
       const decryptedUserData = await decryptUserData(job.userData, this.keyManager)
@@ -3509,7 +3509,9 @@ export class C2DEngineDocker extends C2DEngine {
 
   // Best-effort teardown of a half-created service container + network. Used by the
   // startService / restartService failure paths to avoid leaking Docker networks
-  // (which would exhaust the daemon's IPAM CIDR pool over repeated failures).
+  // (which would exhaust the daemon's IPAM CIDR pool over repeated failures). The network
+  // is removed by deterministic name too, so it is cleaned even when createNetwork itself
+  // threw and no live handle exists.
   private async cleanupServiceDocker(
     container: Dockerode.Container | null,
     network: Dockerode.Network | null,
@@ -3520,8 +3522,64 @@ export class C2DEngineDocker extends C2DEngine {
       await container.stop({ t: 5 }).catch(() => {})
       await container.remove({ force: true }).catch(() => {})
     }
-    if (network) {
-      await network.remove().catch(() => {})
+    await this.removeServiceNetwork(serviceId, network?.id).catch(() => {})
+  }
+
+  // Removes a service's Docker network by BOTH the persisted id (when set) and the
+  // deterministic name `ocean-svc-<serviceId>`: job.networkId is only persisted after the
+  // container starts, so a node crash mid-start leaves networkId='' in the DB while the
+  // named network still exists — removal must never depend solely on the persisted field.
+  // Any container still attached at this point is a stale leftover of the same service
+  // (every caller tears down the known container first), so it is force-removed to
+  // unblock network.remove(). Benign "already gone" errors resolve silently; anything
+  // else propagates so callers can decide whether teardown failure matters.
+  private async removeServiceNetwork(
+    serviceId: string,
+    networkId?: string
+  ): Promise<void> {
+    const refs = new Set<string>([`ocean-svc-${serviceId}`])
+    if (networkId) refs.add(networkId)
+    for (const ref of refs) {
+      const network = this.docker.getNetwork(ref) // dockerode accepts a name or an id
+      let info: any
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        info = await network.inspect()
+      } catch (e: any) {
+        if (isBenignDockerError(e)) continue
+        throw e
+      }
+      for (const containerId of Object.keys(info?.Containers ?? {})) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.docker
+          .getContainer(containerId)
+          .remove({ force: true })
+          .catch((e) => {
+            if (!isBenignDockerError(e)) throw e
+          })
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await network.remove().catch((e) => {
+        if (!isBenignDockerError(e)) throw e
+      })
+    }
+  }
+
+  // createNetwork with self-healing on a 409 name conflict: a conflict means a previous
+  // incarnation of this service leaked its network (e.g. the node died before networkId
+  // was persisted) — remove the stale one and retry once instead of failing the
+  // start/restart forever.
+  private async createServiceNetwork(serviceId: string): Promise<Dockerode.Network> {
+    const Name = `ocean-svc-${serviceId}`
+    try {
+      return await this.docker.createNetwork({ Name })
+    } catch (e: any) {
+      if (e?.statusCode !== 409) throw e
+      CORE_LOGGER.error(
+        `createNetwork conflict for ${Name} — removing stale network and retrying`
+      )
+      await this.removeServiceNetwork(serviceId)
+      return await this.docker.createNetwork({ Name })
     }
   }
 
@@ -3588,10 +3646,9 @@ export class C2DEngineDocker extends C2DEngine {
     await this.db.updateServiceJob(job)
     this.releaseCpus(serviceId)
 
-    // "Already gone" Docker errors (404 missing, 304 already stopped) are the desired end
-    // state, so treat them as success. Any other error means teardown genuinely failed —
-    // record it and keep the job OUT of Stopped so the persisted state stays accurate.
-    const isBenignDockerError = (e: any) => e?.statusCode === 404 || e?.statusCode === 304
+    // Benign "already gone" errors count as success. Any other error means teardown
+    // genuinely failed — record it and keep the job OUT of Stopped so the persisted
+    // state stays accurate.
     let cleanupError: Error | null = null
     try {
       if (job.containerId) {
@@ -3603,14 +3660,7 @@ export class C2DEngineDocker extends C2DEngine {
           if (!isBenignDockerError(e)) throw e
         })
       }
-      if (job.networkId) {
-        await this.docker
-          .getNetwork(job.networkId)
-          .remove()
-          .catch((e) => {
-            if (!isBenignDockerError(e)) throw e
-          })
-      }
+      await this.removeServiceNetwork(serviceId, job.networkId)
       // Only release the reserved host ports once the container is confirmed gone — a
       // port still bound by a not-removed container must not be handed to another service.
       for (const ep of job.endpoints) releaseHostPort(ep.hostPort)
@@ -3651,12 +3701,7 @@ export class C2DEngineDocker extends C2DEngine {
       await c.stop({ t: 10 }).catch(() => {})
       await c.remove({ force: true }).catch(() => {})
     }
-    if (job.networkId) {
-      await this.docker
-        .getNetwork(job.networkId)
-        .remove()
-        .catch(() => {})
-    }
+    await this.removeServiceNetwork(serviceId, job.networkId).catch(() => {})
 
     job.status = ServiceStatusNumber.Starting
     job.statusText = ServiceStatusText[ServiceStatusNumber.Starting]
@@ -3718,7 +3763,7 @@ export class C2DEngineDocker extends C2DEngine {
       })
 
       // 6. New per-service network
-      network = await this.docker.createNetwork({ Name: `ocean-svc-${serviceId}` })
+      network = await this.createServiceNetwork(serviceId)
 
       // 7. Resource constraints
       const { Memory, NanoCpus, DeviceRequests, CpusetCpus } =

--- a/src/test/integration/services.test.ts
+++ b/src/test/integration/services.test.ts
@@ -725,6 +725,63 @@ describe('**********         Service on Demand', () => {
     assert(res.status === 200, `expected nginx HTTP 200 after restart, got ${res.status}`)
   })
 
+  it('(l2) SERVICE_RESTART self-heals a network leaked by a crash mid-start', async function () {
+    this.timeout(DEFAULT_TEST_TIMEOUT * 4)
+    // Simulate a node that died between createNetwork and persisting the docker refs:
+    // the DB record loses containerId/networkId while the real container + network keep
+    // running. Pre-fix, restart then failed forever with Docker 409 ("network with name
+    // ocean-svc-<id> already exists") because teardown only used the empty networkId.
+    const [raw] = await dbconn.c2d.getServiceJob(serviceId)
+    const oldContainerId = raw.containerId
+    raw.containerId = ''
+    raw.networkId = ''
+    raw.status = ServiceStatusNumber.Error
+    raw.statusText = 'simulated crash mid-start'
+    await dbconn.c2d.updateServiceJob(raw)
+
+    const {
+      consumerAddress: addr,
+      nonce,
+      signature
+    } = await signFor(consumerAccount, PROTOCOL_COMMANDS.SERVICE_RESTART)
+    const task: ServiceRestartCommand = {
+      command: PROTOCOL_COMMANDS.SERVICE_RESTART,
+      consumerAddress: addr,
+      nonce,
+      signature,
+      serviceId
+    }
+    const resp = await new ServiceRestartHandler(oceanNode).handle(task)
+    assert(
+      resp.status.httpStatus === 200,
+      `expected 200, got ${resp.status.httpStatus}: ${resp.status?.error ?? ''}`
+    )
+    const running = await pollServiceStatus(serviceId, ServiceStatusNumber.Running)
+    expect(running.containerId).to.not.equal('')
+    expect(running.containerId).to.not.equal(oldContainerId)
+    expect(running.endpoints[0].hostPort).to.equal(hostPort)
+
+    const docker = new Dockerode()
+    // the stale container attached to the leaked network must have been force-removed
+    let staleGone = false
+    try {
+      await docker.getContainer(oldContainerId).inspect()
+    } catch {
+      staleGone = true
+    }
+    assert(staleGone, 'stale container should have been force-removed')
+    // exactly one network with the deterministic name survives
+    const nets = await docker.listNetworks()
+    const matching = nets.filter((n: any) => n.Name === `ocean-svc-${serviceId}`)
+    expect(matching.length).to.equal(1)
+
+    const res = await httpGetWithRetry(endpointUrl)
+    assert(
+      res.status === 200,
+      `expected nginx HTTP 200 after self-heal, got ${res.status}`
+    )
+  })
+
   it('(m) SERVICE_STOP → Stopped, container + network removed', async function () {
     this.timeout(DEFAULT_TEST_TIMEOUT * 2)
     const before = await getServiceJob(serviceId)
@@ -759,6 +816,11 @@ describe('**********         Service on Demand', () => {
       inspectFailed = true
     }
     assert(inspectFailed, 'container should have been removed')
+
+    // network should be gone too (removed by deterministic name, independent of networkId)
+    const nets = await docker.listNetworks()
+    const matching = nets.filter((n: any) => n.Name === `ocean-svc-${serviceId}`)
+    expect(matching.length).to.equal(0)
   })
 
   it('(n) [slow] expiry cron marks a short-lived service Expired', async function () {

--- a/src/test/unit/compute.test.ts
+++ b/src/test/unit/compute.test.ts
@@ -1289,7 +1289,7 @@ describe('getAlgoChecksums', () => {
 
 describe('service start/restart Docker cleanup on failure', function () {
   let engine: any
-  let network: { id: string; remove: sinon.SinonStub }
+  let network: { id: string; inspect: sinon.SinonStub; remove: sinon.SinonStub }
 
   function makeContainer(startRejects: boolean) {
     return {
@@ -1309,7 +1309,13 @@ describe('service start/restart Docker cleanup on failure', function () {
     // pinning maps that releaseCpus/allocateCpus (called by cleanupServiceDocker) touch.
     engine.cpuAllocations = new Map()
     engine.envCpuCoresMap = new Map()
-    network = { id: 'net-1', remove: sinon.stub().resolves() }
+    // inspect is needed by removeServiceNetwork (cleanup resolves the network by
+    // deterministic name/id and checks for attached containers before removing).
+    network = {
+      id: 'net-1',
+      inspect: sinon.stub().resolves({ Containers: {} }),
+      remove: sinon.stub().resolves()
+    }
 
     engine.db = {
       newServiceJob: sinon.stub().resolves(),
@@ -1385,13 +1391,14 @@ describe('service start/restart Docker cleanup on failure', function () {
   it('processServiceStart removes the network and marks Error when createContainer fails', async function () {
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().rejects(new Error('createContainer failed'))
+      createContainer: sinon.stub().rejects(new Error('createContainer failed')),
+      getNetwork: sinon.stub().returns(network)
     }
     const job = makeStartingJob({ serviceId: 'svc-1' })
 
     await engine.processServiceStart(job) // never throws — failures are persisted as status
 
-    expect(network.remove.calledOnce, 'network.remove should be called').to.equal(true)
+    expect(network.remove.called, 'network.remove should be called').to.equal(true)
     expect(job.status).to.equal(ServiceStatusNumber.Error)
     // Funds were already claimed before the container step, so no refund here.
     expect(engine.escrow.claimLock.calledOnce).to.equal(true)
@@ -1402,7 +1409,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     const container = makeContainer(true)
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().resolves(container)
+      createContainer: sinon.stub().resolves(container),
+      getNetwork: sinon.stub().returns(network)
     }
     const job = makeStartingJob({ serviceId: 'svc-2' })
 
@@ -1411,7 +1419,7 @@ describe('service start/restart Docker cleanup on failure', function () {
     expect(container.remove.calledOnce, 'container.remove should be called').to.equal(
       true
     )
-    expect(network.remove.calledOnce, 'network.remove should be called').to.equal(true)
+    expect(network.remove.called, 'network.remove should be called').to.equal(true)
     expect(job.status).to.equal(ServiceStatusNumber.Error)
   })
 
@@ -1419,7 +1427,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     engine.pullImageRef = sinon.stub().rejects(new Error('pull failed'))
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().resolves(makeContainer(false))
+      createContainer: sinon.stub().resolves(makeContainer(false)),
+      getNetwork: sinon.stub().returns(network)
     }
     const job = makeStartingJob({ serviceId: 'svc-img' })
 
@@ -1439,7 +1448,11 @@ describe('service start/restart Docker cleanup on failure', function () {
 
   it('processServiceStart marks Error and skips the image when createLock fails', async function () {
     engine.escrow.createLock = sinon.stub().resolves(null)
-    engine.docker = { createNetwork: sinon.stub(), createContainer: sinon.stub() }
+    engine.docker = {
+      createNetwork: sinon.stub(),
+      createContainer: sinon.stub(),
+      getNetwork: sinon.stub().returns(network)
+    }
     const job = makeStartingJob({ serviceId: 'svc-lock' })
 
     await engine.processServiceStart(job)
@@ -1450,7 +1463,11 @@ describe('service start/restart Docker cleanup on failure', function () {
   })
 
   it('processServiceStart orphan recovery: cancels an unclaimed lock and marks Error', async function () {
-    engine.docker = { createNetwork: sinon.stub(), createContainer: sinon.stub() }
+    engine.docker = {
+      createNetwork: sinon.stub(),
+      createContainer: sinon.stub(),
+      getNetwork: sinon.stub().returns(network)
+    }
     // Resuming a job left in Locking from a previous process, with a lock but no claim.
     const job = makeStartingJob({
       serviceId: 'svc-orphan',
@@ -1500,7 +1517,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     engine.db.getServiceJob = sinon.stub().resolves([existingJob])
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().rejects(new Error('createContainer failed'))
+      createContainer: sinon.stub().rejects(new Error('createContainer failed')),
+      getNetwork: sinon.stub().returns(network)
     }
 
     await expectRejects(
@@ -1508,7 +1526,7 @@ describe('service start/restart Docker cleanup on failure', function () {
       'createContainer failed'
     )
 
-    expect(network.remove.calledOnce, 'network.remove should be called').to.equal(true)
+    expect(network.remove.called, 'network.remove should be called').to.equal(true)
   })
 
   function makeRunningJobWithCmd(overrides: any = {}) {
@@ -1543,7 +1561,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     const container = makeContainer(false)
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().resolves(container)
+      createContainer: sinon.stub().resolves(container),
+      getNetwork: sinon.stub().returns(network)
     }
 
     const result = await engine.restartService(
@@ -1567,7 +1586,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     const container = makeContainer(false)
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().resolves(container)
+      createContainer: sinon.stub().resolves(container),
+      getNetwork: sinon.stub().returns(network)
     }
 
     const result = await engine.restartService('svc-cmd', '0xowner', undefined)
@@ -1585,7 +1605,8 @@ describe('service start/restart Docker cleanup on failure', function () {
     const container = makeContainer(false)
     engine.docker = {
       createNetwork: sinon.stub().resolves(network),
-      createContainer: sinon.stub().resolves(container)
+      createContainer: sinon.stub().resolves(container),
+      getNetwork: sinon.stub().returns(network)
     }
 
     const result = await engine.restartService('svc-cmd', '0xowner', undefined, [], [])

--- a/src/test/unit/service/serviceNetworkCleanup.test.ts
+++ b/src/test/unit/service/serviceNetworkCleanup.test.ts
@@ -1,0 +1,223 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { C2DEngineDocker } from '../../../components/c2d/compute_engine_docker.js'
+import { ServiceStatusNumber, ServiceJob } from '../../../@types/C2D/ServiceOnDemand.js'
+
+const OWNER = '0x0000000000000000000000000000000000000001'
+const SERVICE_ID = 'svc-1'
+const NETWORK_NAME = `ocean-svc-${SERVICE_ID}`
+
+function makeJob(overrides: Partial<ServiceJob> = {}): ServiceJob {
+  return {
+    serviceId: SERVICE_ID,
+    clusterHash: 'hash-1',
+    environment: 'env-1',
+    owner: OWNER,
+    image: 'img',
+    tag: 'latest',
+    containerImage: 'img:latest',
+    containerId: 'c1',
+    networkId: 'n1',
+    status: ServiceStatusNumber.Running,
+    statusText: 'Running',
+    dateCreated: new Date(0).toISOString(),
+    expiresAt: Date.now() + 3600_000,
+    duration: 3600,
+    exposedPorts: [8888],
+    endpoints: [{ containerPort: 8888, hostPort: 31000, url: 'http://localhost:31000' }],
+    userData: 'ENCRYPTED',
+    resources: [{ id: 'cpu', amount: 2 }],
+    payment: {
+      chainId: 8996,
+      token: '0xtoken',
+      lockTx: '0xl',
+      claimTx: '0xc',
+      cancelTx: '',
+      cost: 5
+    },
+    ...overrides
+  }
+}
+
+function benignError(statusCode: number = 404) {
+  const e: any = new Error(`docker ${statusCode}`)
+  e.statusCode = statusCode
+  return e
+}
+
+// Fake dockerode network handle: inspect() result (or rejection) and remove() behavior
+// are configurable per test.
+function fakeNetwork(opts: {
+  inspect?: any
+  inspectError?: any
+  removeError?: any
+}): any {
+  return {
+    inspect: opts.inspectError
+      ? sinon.stub().rejects(opts.inspectError)
+      : sinon.stub().resolves(opts.inspect ?? { Containers: {} }),
+    remove: opts.removeError
+      ? sinon.stub().rejects(opts.removeError)
+      : sinon.stub().resolves(undefined)
+  }
+}
+
+// Bypass the Docker-specific constructor while retaining the prototype chain (same
+// pattern as compute.test.ts) so private methods can be exercised with a stubbed docker.
+function makeEngine(): any {
+  const engine: any = Object.create(C2DEngineDocker.prototype)
+  engine.docker = {
+    getNetwork: sinon.stub(),
+    getContainer: sinon.stub(),
+    createNetwork: sinon.stub()
+  }
+  engine.cpuAllocations = new Map()
+  return engine
+}
+
+describe('service network cleanup (leaked ocean-svc-<id> networks)', () => {
+  afterEach(() => sinon.restore())
+
+  describe('removeServiceNetwork()', () => {
+    it('removes the network by deterministic name when networkId is empty (leak scenario)', async () => {
+      const engine = makeEngine()
+      const network = fakeNetwork({})
+      engine.docker.getNetwork.returns(network)
+
+      await engine.removeServiceNetwork(SERVICE_ID)
+
+      expect(engine.docker.getNetwork.calledOnceWith(NETWORK_NAME)).to.equal(true)
+      expect(network.remove.calledOnce).to.equal(true)
+    })
+
+    it('tries both the persisted id and the deterministic name', async () => {
+      const engine = makeEngine()
+      const byName = fakeNetwork({})
+      // after the first ref is removed, the second ref's inspect 404s and is skipped
+      const byId = fakeNetwork({ inspectError: benignError(404) })
+      engine.docker.getNetwork.withArgs(NETWORK_NAME).returns(byName)
+      engine.docker.getNetwork.withArgs('n1').returns(byId)
+
+      await engine.removeServiceNetwork(SERVICE_ID, 'n1')
+
+      expect(engine.docker.getNetwork.calledWith(NETWORK_NAME)).to.equal(true)
+      expect(engine.docker.getNetwork.calledWith('n1')).to.equal(true)
+      expect(byName.remove.calledOnce).to.equal(true)
+      expect(byId.remove.called).to.equal(false)
+    })
+
+    it('force-removes stale attached containers before removing the network', async () => {
+      const engine = makeEngine()
+      const network = fakeNetwork({ inspect: { Containers: { cid1: {}, cid2: {} } } })
+      engine.docker.getNetwork.returns(network)
+      const containerRemove = sinon.stub().resolves(undefined)
+      engine.docker.getContainer.returns({ remove: containerRemove })
+
+      await engine.removeServiceNetwork(SERVICE_ID)
+
+      expect(engine.docker.getContainer.calledWith('cid1')).to.equal(true)
+      expect(engine.docker.getContainer.calledWith('cid2')).to.equal(true)
+      expect(containerRemove.alwaysCalledWith({ force: true })).to.equal(true)
+      expect(network.remove.calledOnce).to.equal(true)
+      expect(containerRemove.calledBefore(network.remove)).to.equal(true)
+    })
+
+    it('resolves silently when the network is already gone (404 inspect / 404 remove)', async () => {
+      const engine = makeEngine()
+      const gone = fakeNetwork({ inspectError: benignError(404) })
+      engine.docker.getNetwork.returns(gone)
+      await engine.removeServiceNetwork(SERVICE_ID)
+      expect(gone.remove.called).to.equal(false)
+
+      const goneOnRemove = fakeNetwork({ removeError: benignError(404) })
+      engine.docker.getNetwork.returns(goneOnRemove)
+      await engine.removeServiceNetwork(SERVICE_ID)
+      expect(goneOnRemove.remove.calledOnce).to.equal(true)
+    })
+
+    it('propagates non-benign docker errors', async () => {
+      const engine = makeEngine()
+      engine.docker.getNetwork.returns(fakeNetwork({ inspectError: benignError(500) }))
+      try {
+        await engine.removeServiceNetwork(SERVICE_ID)
+        expect.fail('expected removeServiceNetwork to reject')
+      } catch (e: any) {
+        expect(e.statusCode).to.equal(500)
+      }
+
+      engine.docker.getNetwork.returns(fakeNetwork({ removeError: benignError(500) }))
+      try {
+        await engine.removeServiceNetwork(SERVICE_ID)
+        expect.fail('expected removeServiceNetwork to reject')
+      } catch (e: any) {
+        expect(e.statusCode).to.equal(500)
+      }
+    })
+  })
+
+  describe('createServiceNetwork()', () => {
+    it('returns the created network on the happy path', async () => {
+      const engine = makeEngine()
+      const created = { id: 'newnet' }
+      engine.docker.createNetwork.resolves(created)
+
+      const result = await engine.createServiceNetwork(SERVICE_ID)
+
+      expect(result).to.equal(created)
+      expect(engine.docker.createNetwork.calledOnceWith({ Name: NETWORK_NAME })).to.equal(
+        true
+      )
+    })
+
+    it('on 409 removes the stale network and retries once (self-heal)', async () => {
+      const engine = makeEngine()
+      const created = { id: 'newnet' }
+      engine.docker.createNetwork
+        .onFirstCall()
+        .rejects(benignError(409))
+        .onSecondCall()
+        .resolves(created)
+      const stale = fakeNetwork({})
+      engine.docker.getNetwork.returns(stale)
+
+      const result = await engine.createServiceNetwork(SERVICE_ID)
+
+      expect(result).to.equal(created)
+      expect(stale.remove.calledOnce).to.equal(true)
+      expect(engine.docker.createNetwork.calledTwice).to.equal(true)
+    })
+
+    it('does not retry on non-409 errors', async () => {
+      const engine = makeEngine()
+      engine.docker.createNetwork.rejects(benignError(500))
+
+      try {
+        await engine.createServiceNetwork(SERVICE_ID)
+        expect.fail('expected createServiceNetwork to reject')
+      } catch (e: any) {
+        expect(e.statusCode).to.equal(500)
+      }
+      expect(engine.docker.createNetwork.calledOnce).to.equal(true)
+      expect(engine.docker.getNetwork.called).to.equal(false)
+    })
+  })
+
+  describe('stopService() with a leaked network (empty networkId)', () => {
+    it('removes the network by deterministic name and ends Stopped', async () => {
+      const engine = makeEngine()
+      const job = makeJob({ containerId: '', networkId: '' })
+      engine.db = {
+        getServiceJob: sinon.stub().resolves([job]),
+        updateServiceJob: sinon.stub().resolves(1)
+      }
+      const network = fakeNetwork({})
+      engine.docker.getNetwork.returns(network)
+
+      const result = await engine.stopService(SERVICE_ID, OWNER)
+
+      expect(engine.docker.getNetwork.calledWith(NETWORK_NAME)).to.equal(true)
+      expect(network.remove.calledOnce).to.equal(true)
+      expect(result.status).to.equal(ServiceStatusNumber.Stopped)
+    })
+  })
+})


### PR DESCRIPTION
Closing #1415 
# Fix: service restart wedged by leaked Docker network (409 "network already exists")

Restarting a Service-on-Demand job could fail permanently with
`(HTTP code 409) unexpected - network with name ocean-svc-<serviceId> already exists`,
leaving the job stuck in `Error` (99) with empty `containerId`/`networkId` — and every
subsequent restart failing the same way, with no way out short of manual `docker network rm`
on the host.

## Root cause

Each service gets a Docker network with a **deterministic name** (`ocean-svc-<serviceId>`),
but every cleanup path (restart teardown, stop, orphan recovery, expiry sweep) removed it
only via the **persisted `job.networkId`** field. That field is written only *after* the
container starts successfully, so a node crash (or error) between `createNetwork` and that
persist leaked the network with `networkId=''` in the DB. From then on, restart skipped
teardown (empty id), hit the leftover named network at `createNetwork` → Docker 409 → job
marked `Error` — a self-perpetuating dead end. Leaked networks were also never reaped by the
expiry sweep (same gate), permanently consuming the Docker daemon's limited IPAM subnet pool.

## What changed

All in `src/components/c2d/compute_engine_docker.ts`:

- **`removeServiceNetwork(serviceId, networkId?)`** (new): removes the service network by
  **both** the persisted id (when set) and the deterministic name, so cleanup never depends
  solely on the DB field. If the network still has stale attached containers (crash after
  `container.start()` but before the persist), they are force-removed first — otherwise
  `network.remove()` fails with "has active endpoints". Benign Docker errors (404/304 =
  already gone) count as success; anything else propagates.
- **`createServiceNetwork(serviceId)`** (new): wraps `createNetwork`; on a 409 name conflict
  it removes the stale network and retries once. This makes already-broken jobs (like the
  reported one) **self-heal on the next restart** with no manual intervention or DB surgery.
  The stale network is removed and recreated rather than reused: reuse saves nothing (a
  leaked network can still hold a stale container bound to the service's host ports, which
  must be inspected and force-removed either way), a fresh network always reflects the
  current code's configuration instead of inheriting options from whatever node version
  leaked it, and remove+recreate matches restart's tear-down-and-rebuild semantics — the
  container is never reused either.
- All four cleanup paths now go through the helper: `restartService` pre-teardown,
  `stopService`, `processServiceStart` orphan recovery, and `cleanupServiceDocker`
  (failure-path cleanup — now works even when `createNetwork` itself threw and no live
  handle exists). Both `createNetwork` call sites (initial start + restart) use the
  self-healing wrapper.
- Since the expiry sweep funnels `Running`/`Error` jobs through `stopService`, leaked
  networks from abandoned jobs are now reaped automatically too — no schema or sweep changes.
- `isBenignDockerError` hoisted from `stopService` to module scope (shared, unchanged).

No handler/API changes: `Error`-status jobs were already restartable; the bug was entirely
engine-side. `markServiceFailed` still deliberately leaves Docker resources in place for
restart to reclaim — reclaiming is just reliable now.

## Tests

- **Unit** (`src/test/unit/service/serviceNetworkCleanup.test.ts`, no Docker daemon):
  removal by deterministic name with empty `networkId` (the exact leak scenario), stale
  attached containers force-removed before network removal, benign 404/304 vs propagated
  errors, 409 → remove + retry-once (and no retry on other errors), and `stopService`
  end-to-end with a leaked network ending `Stopped`.
- **Integration** (`src/test/integration/services.test.ts`): new case simulates the
  post-crash DB state (`containerId=''`, `networkId=''`, `status=Error` while the real
  container + network keep running) and asserts `SERVICE_RESTART` succeeds (pre-fix: 500
  with the 409 message), the service returns to `Running` on the same host port, the stale
  container is gone, and exactly one `ocean-svc-<serviceId>` network remains. The stop test
  now also asserts the network is gone by name.
- Docs: `docs/services.md` notes the self-healing teardown semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restart and stop reliability after interrupted starts or node crashes.
  * Automatically removes stale containers and Docker networks that could block service recovery.
  * Added recovery for network-name conflicts during service startup.
  * Ensured failed container starts correctly report an error status.

* **Documentation**
  * Clarified service network cleanup and restart behavior.

* **Tests**
  * Added coverage for stale network recovery, cleanup, and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->