### PR TITLE
remove axios

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "jest": true
   },
   "globals": {
-    "NodeJS": true
+    "NodeJS": true,
+    "RequestInit": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@multiformats/multiaddr": "^12.2.3",
         "@oceanprotocol/contracts": "^2.9.0",
         "@oceanprotocol/ddo-js": "^0.4.0",
-        "axios": "^1.15.0",
         "base58-js": "^2.0.0",
         "basic-ftp": "^5.3.1",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@multiformats/multiaddr": "^12.2.3",
     "@oceanprotocol/contracts": "^2.9.0",
     "@oceanprotocol/ddo-js": "^0.4.0",
-    "axios": "^1.15.0",
     "base58-js": "^2.0.0",
     "basic-ftp": "^5.3.1",
     "cors": "^2.8.5",

--- a/src/components/Indexer/processors/BaseProcessor.ts
+++ b/src/components/Indexer/processors/BaseProcessor.ts
@@ -1,5 +1,4 @@
 import { VersionedDDO, DeprecatedDDO } from '@oceanprotocol/ddo-js'
-import axios from 'axios'
 import {
   ZeroAddress,
   Signer,
@@ -222,12 +221,13 @@ export abstract class BaseEventProcessor {
         INDEXER_LOGGER.logMessage(
           `decryptDDO: Making HTTP request for nonce. DecryptorURL: ${decryptorURL}`
         )
-        const nonceResponse = await axios.get(
+        const nonceResponse = await fetch(
           `${decryptorURL}/api/services/nonce?userAddress=${address}`,
-          { timeout: 20000 }
+          { signal: AbortSignal.timeout(20000) }
         )
-        return nonceResponse.status === 200 && nonceResponse.data
-          ? String(parseInt(nonceResponse.data.nonce) + 1)
+        const nonceData = nonceResponse.status === 200 ? await nonceResponse.json() : null
+        return nonceData?.nonce !== undefined
+          ? String(parseInt(nonceData.nonce) + 1)
           : Date.now().toString()
       } else {
         return Date.now().toString()
@@ -287,17 +287,23 @@ export abstract class BaseEventProcessor {
               nonce
             }
             try {
-              const res = await axios({
-                method: 'post',
-                url: `${decryptorURL}/api/services/decrypt`,
-                data: payload,
-                timeout: 30000,
-                validateStatus: (status) => {
-                  return (
-                    (status >= 200 && status < 300) || status === 400 || status === 403
-                  )
-                }
+              // fetch never throws on HTTP status; the manual status checks below
+              // reproduce the previous axios validateStatus contract (2xx/400/403
+              // handled here, everything else throws and is retried by withRetrial).
+              const fetchRes = await fetch(`${decryptorURL}/api/services/decrypt`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(payload),
+                signal: AbortSignal.timeout(30000)
               })
+              const decryptContentType = fetchRes.headers.get('content-type') ?? ''
+              const res = {
+                status: fetchRes.status,
+                statusText: fetchRes.statusText,
+                data: decryptContentType.startsWith('application/json')
+                  ? await fetchRes.json()
+                  : await fetchRes.text()
+              }
 
               INDEXER_LOGGER.log(
                 LOG_LEVELS_STR.LEVEL_INFO,
@@ -320,9 +326,11 @@ export abstract class BaseEventProcessor {
               }
               return res
             } catch (err: any) {
-              // Retry ONLY on ECONNREFUSED
+              // Retry ONLY on ECONNREFUSED. fetch wraps the OS error in
+              // `err.cause`, so check both there and on the error itself.
               if (
                 err.code === 'ECONNREFUSED' ||
+                err.cause?.code === 'ECONNREFUSED' ||
                 (err.message && err.message.includes('ECONNREFUSED'))
               ) {
                 INDEXER_LOGGER.log(

--- a/src/components/Indexer/processors/BaseProcessor.ts
+++ b/src/components/Indexer/processors/BaseProcessor.ts
@@ -296,13 +296,22 @@ export abstract class BaseEventProcessor {
                 body: JSON.stringify(payload),
                 signal: AbortSignal.timeout(30000)
               })
-              const decryptContentType = fetchRes.headers.get('content-type') ?? ''
+              // axios's default transformResponse parsed JSON regardless of the
+              // content-type, falling back to the raw string. The decrypt endpoint
+              // returns the DDO as JSON but with a text/plain content-type, so a
+              // content-type gate would wrongly keep it a string and downstream
+              // create256Hash would receive an object. Replicate axios here.
+              const rawBody = await fetchRes.text()
+              let parsedBody: any = rawBody
+              try {
+                parsedBody = JSON.parse(rawBody)
+              } catch {
+                // not JSON — keep the raw string, same as axios did
+              }
               const res = {
                 status: fetchRes.status,
                 statusText: fetchRes.statusText,
-                data: decryptContentType.startsWith('application/json')
-                  ? await fetchRes.json()
-                  : await fetchRes.text()
+                data: parsedBody
               }
 
               INDEXER_LOGGER.log(

--- a/src/components/Indexer/purgatory.ts
+++ b/src/components/Indexer/purgatory.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { PurgatoryAccounts, PurgatoryAssets } from '../../@types/Purgatory.js'
 import { INDEXER_LOGGER } from '../../utils/logging/common.js'
 import { LOG_LEVELS_STR } from '../../utils/logging/Logger.js'
@@ -43,16 +42,15 @@ export class Purgatory {
     const purgatoryAssets: Array<PurgatoryAssets> = []
     if (this.isAssetsPurgatoryEnabled()) {
       try {
-        const response = await axios({
-          method: 'get',
-          url: this.assetPurgatoryUrl,
-          timeout: 2000
+        const response = await fetch(this.assetPurgatoryUrl, {
+          method: 'GET',
+          signal: AbortSignal.timeout(2000)
         })
         if (response.status !== 200) {
           INDEXER_LOGGER.log(
             LOG_LEVELS_STR.LEVEL_ERROR,
             `PURGATORY: Failure when retrieving new purgatory list from ASSET_PURGATORY_URL env var.
-                Response: ${response.data}, status: ${
+                Response: ${await response.text()}, status: ${
                   response.status + response.statusText
                 }`,
             true
@@ -63,7 +61,8 @@ export class Purgatory {
           `PURGATORY: Successfully retrieved new purgatory list from ASSET_PURGATORY_URL env var.`
         )
 
-        for (const asset of response.data) {
+        const assets = await response.json()
+        for (const asset of assets) {
           if (asset && 'did' in asset) {
             purgatoryAssets.push({ did: asset.did, reason: asset.reason })
           }
@@ -86,16 +85,15 @@ export class Purgatory {
     const purgatoryAccounts: Array<PurgatoryAccounts> = []
     if (this.isAccountsPurgatoryEnabled()) {
       try {
-        const response = await axios({
-          method: 'get',
-          url: this.accountPurgatoryUrl,
-          timeout: 2000 // small increase
+        const response = await fetch(this.accountPurgatoryUrl, {
+          method: 'GET',
+          signal: AbortSignal.timeout(2000) // small increase
         })
         if (response.status !== 200) {
           INDEXER_LOGGER.log(
             LOG_LEVELS_STR.LEVEL_ERROR,
             `PURGATORY: Failure when retrieving new purgatory list from ACCOUNT_PURGATORY_URL env var.
-              Response: ${response.data}, status: ${
+              Response: ${await response.text()}, status: ${
                 response.status + response.statusText
               }`,
             true
@@ -105,7 +103,8 @@ export class Purgatory {
         INDEXER_LOGGER.logMessage(
           `PURGATORY: Successfully retrieved new purgatory list from ACCOUNT_PURGATORY_URL env var.`
         )
-        for (const account of response.data) {
+        const accounts = await response.json()
+        for (const account of accounts) {
           if (account && 'address' in account) {
             purgatoryAccounts.push({ address: account.address, reason: account.reason })
           }

--- a/src/components/database/typesenseApi.ts
+++ b/src/components/database/typesenseApi.ts
@@ -110,7 +110,14 @@ export class TypesenseApi {
             'X-TYPESENSE-API-KEY': this.config.apiKey,
             ...(bodyParameters !== null && { 'content-type': 'application/json' })
           },
-          ...(bodyParameters !== null && { body: JSON.stringify(bodyParameters) })
+          // axios sent string bodies raw; only stringify non-string bodies so a
+          // pre-serialized payload (e.g. JSONL) isn't double-encoded
+          ...(bodyParameters !== null && {
+            body:
+              typeof bodyParameters === 'string'
+                ? bodyParameters
+                : JSON.stringify(bodyParameters)
+          })
         }
 
         if (skipConnectionTimeout !== true) {
@@ -134,7 +141,8 @@ export class TypesenseApi {
         } else if (response.status < 500) {
           return Promise.reject(this.customError(response.status, data))
         } else {
-          throw new Error(data?.message)
+          // non-json error bodies (e.g. a proxy 5xx) arrive as a plain string
+          throw new Error(typeof data === 'string' ? data : data?.message)
         }
       } catch (error: any) {
         lastException = error
@@ -154,7 +162,9 @@ export class TypesenseApi {
   }
 
   customError(status: number, data: any): TypesenseError {
-    const error = new TypesenseError(data?.message)
+    // non-json error bodies (e.g. a proxy 4xx) arrive as a plain string
+    const message = typeof data === 'string' ? data : data?.message
+    const error = new TypesenseError(message)
     error.httpStatus = status
     return error
   }

--- a/src/components/database/typesenseApi.ts
+++ b/src/components/database/typesenseApi.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { setTimeout } from 'timers/promises'
 import { TypesenseConfig } from './typesenseConfig.js'
 import { TypesenseError } from './typesense.js'
@@ -96,60 +95,53 @@ export class TypesenseApi {
       )
 
       try {
-        const url = `${node.protocol}://${node.host}:${node.port}${endpoint}`
-        const requestOptions: AxiosRequestConfig = {
-          method: requestType,
-          url,
-          headers: { 'X-TYPESENSE-API-KEY': this.config.apiKey },
-          maxContentLength: Infinity,
-          maxBodyLength: Infinity,
-          validateStatus: (status) => {
-            return status > 0
-          },
-          transformResponse: [
-            (data, headers) => {
-              let transformedData = data
-              if (
-                headers !== undefined &&
-                typeof data === 'string' &&
-                headers['content-type'] &&
-                headers['content-type'].startsWith('application/json')
-              ) {
-                transformedData = JSON.parse(data)
-              }
-              return transformedData
+        const url = new URL(`${node.protocol}://${node.host}:${node.port}${endpoint}`)
+        if (queryParameters !== null) {
+          for (const [key, value] of Object.entries(queryParameters)) {
+            if (value !== undefined && value !== null) {
+              url.searchParams.set(key, String(value))
             }
-          ]
+          }
+        }
+
+        const init: RequestInit = {
+          method: requestType.toUpperCase(),
+          headers: {
+            'X-TYPESENSE-API-KEY': this.config.apiKey,
+            ...(bodyParameters !== null && { 'content-type': 'application/json' })
+          },
+          ...(bodyParameters !== null && { body: JSON.stringify(bodyParameters) })
         }
 
         if (skipConnectionTimeout !== true) {
-          requestOptions.timeout = this.config.connectionTimeoutSeconds * 1000
+          init.signal = AbortSignal.timeout(this.config.connectionTimeoutSeconds * 1000)
         }
 
-        if (queryParameters !== null) {
-          requestOptions.params = queryParameters
-        }
-
-        if (bodyParameters !== null) {
-          requestOptions.data = bodyParameters
-        }
-
-        const response = await axios(requestOptions)
+        const response = await fetch(url, init)
         this.config.logger.debug(
           `Request ${endpoint}: Request to Node ${node.host} was made. Response Code was ${response.status}.`
         )
 
+        // fetch never throws on HTTP status and doesn't auto-parse — replicate
+        // axios's old transformResponse (JSON only when content-type says so).
+        const contentType = response.headers.get('content-type') ?? ''
+        const data: any = contentType.startsWith('application/json')
+          ? await response.json()
+          : await response.text()
+
         if (response.status >= 200 && response.status < 300) {
-          return Promise.resolve(response.data)
+          return data
         } else if (response.status < 500) {
-          return Promise.reject(this.customError(response))
+          return Promise.reject(this.customError(response.status, data))
         } else {
-          throw new Error(response.data?.message)
+          throw new Error(data?.message)
         }
       } catch (error: any) {
         lastException = error
         this.config.logger.debug(
-          `Request ${endpoint}: Request to Node ${node.host} failed due to "${error.code} ${error.message}"`
+          `Request ${endpoint}: Request to Node ${node.host} failed due to "${
+            error.cause?.code ?? error.code
+          } ${error.message}"`
         )
         this.config.logger.debug(
           `Request ${endpoint}: Sleeping for ${this.config.retryIntervalSeconds}s and then retrying request...`
@@ -161,9 +153,9 @@ export class TypesenseApi {
     return Promise.reject(lastException)
   }
 
-  customError(response: AxiosResponse): TypesenseError {
-    const error = new TypesenseError(response.data?.message)
-    error.httpStatus = response.status
+  customError(status: number, data: any): TypesenseError {
+    const error = new TypesenseError(data?.message)
+    error.httpStatus = status
     return error
   }
 }

--- a/src/components/storage/ArweaveStorage.ts
+++ b/src/components/storage/ArweaveStorage.ts
@@ -5,8 +5,8 @@ import {
 } from '../../@types/fileObject.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { fetchFileMetadata } from '../../utils/asset.js'
+import { fetchStream } from '../../utils/http.js'
 import urlJoin from 'url-join'
-import axios from 'axios'
 import { Storage } from './Storage.js'
 
 export class ArweaveStorage extends Storage {
@@ -55,18 +55,7 @@ export class ArweaveStorage extends Storage {
 
   override async getReadableStream(): Promise<StorageReadable> {
     const input = this.getDownloadUrl()
-    const response = await axios({
-      method: 'get',
-      url: input,
-      responseType: 'stream',
-      timeout: 30000
-    })
-
-    return {
-      httpStatus: response.status,
-      stream: response.data,
-      headers: response.headers as any
-    }
+    return await fetchStream(input, { method: 'GET' }, 30000)
   }
 
   async fetchSpecificFileMetadata(

--- a/src/components/storage/IpfsStorage.ts
+++ b/src/components/storage/IpfsStorage.ts
@@ -5,8 +5,8 @@ import {
 } from '../../@types/fileObject.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { fetchFileMetadata } from '../../utils/asset.js'
+import { fetchStream } from '../../utils/http.js'
 import urlJoin from 'url-join'
-import axios from 'axios'
 import { Storage } from './Storage.js'
 
 export class IpfsStorage extends Storage {
@@ -49,18 +49,7 @@ export class IpfsStorage extends Storage {
 
   override async getReadableStream(): Promise<StorageReadable> {
     const input = this.getDownloadUrl()
-    const response = await axios({
-      method: 'get',
-      url: input,
-      responseType: 'stream',
-      timeout: 30000
-    })
-
-    return {
-      httpStatus: response.status,
-      stream: response.data,
-      headers: response.headers as any
-    }
+    return await fetchStream(input, { method: 'GET' }, 30000)
   }
 
   async fetchSpecificFileMetadata(

--- a/src/components/storage/UrlStorage.ts
+++ b/src/components/storage/UrlStorage.ts
@@ -6,7 +6,7 @@ import {
 } from '../../@types/fileObject.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { fetchFileMetadata } from '../../utils/asset.js'
-import axios from 'axios'
+import { fetchStream, fetchHeadersTimeout, headersToObject } from '../../utils/http.js'
 
 import { Storage } from './Storage.js'
 
@@ -23,19 +23,8 @@ export class UrlStorage extends Storage {
     const input = this.getDownloadUrl()
     const file = this.getFile()
     const { headers } = file
-    const response = await axios({
-      method: 'get',
-      url: input,
-      headers,
-      responseType: 'stream',
-      timeout: 30000
-    })
-
-    return {
-      httpStatus: response.status,
-      stream: response.data,
-      headers: response.headers as any
-    }
+    // download always uses GET regardless of file.method (which applies to metadata fetch)
+    return await fetchStream(input, { method: 'GET', headers }, 30000)
   }
 
   /**
@@ -57,18 +46,26 @@ export class UrlStorage extends Storage {
       ...(fileHeaders ?? {}),
       'Content-Disposition': `attachment; filename="${filename.replace(/"/g, '\\"')}"`
     }
-    const response = await axios({
-      method: 'put',
+    const response = await fetchHeadersTimeout(
       url,
-      data: stream,
-      headers,
-      timeout: 30000,
-      maxBodyLength: Infinity,
-      maxContentLength: Infinity
-    })
+      {
+        method: 'PUT',
+        headers,
+        // streaming a Node Readable as the request body requires a web stream
+        // plus duplex: 'half' (mandatory in undici) — chunked, no content-length.
+        // duplex isn't in the DOM RequestInit type, so cast the whole init.
+        body: Readable.toWeb(stream) as any,
+        duplex: 'half'
+      } as RequestInit,
+      30000
+    )
+    if (!response.ok) {
+      // axios threw on non-2xx PUT; the caller relies on that to fail the job
+      throw new Error(`Upload failed with status code ${response.status} (${url})`)
+    }
     return {
       httpStatus: response.status,
-      headers: response.headers as Record<string, string | string[]>
+      headers: headersToObject(response.headers)
     }
   }
 

--- a/src/components/storage/UrlStorage.ts
+++ b/src/components/storage/UrlStorage.ts
@@ -60,7 +60,9 @@ export class UrlStorage extends Storage {
       30000
     )
     if (!response.ok) {
-      // axios threw on non-2xx PUT; the caller relies on that to fail the job
+      // axios threw on non-2xx PUT; the caller relies on that to fail the job.
+      // cancel the undrained body so undici releases the socket back to the pool.
+      await response.body?.cancel().catch(() => {})
       throw new Error(`Upload failed with status code ${response.status} (${url})`)
     }
     return {

--- a/src/test/unit/http.test.ts
+++ b/src/test/unit/http.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import http, { Server } from 'http'
 import { AddressInfo } from 'net'
 import { Readable } from 'stream'
+import { gzipSync } from 'zlib'
 import { fetchStream, fetchHeadersTimeout, headersToObject } from '../../utils/http.js'
 
 // spin up a throwaway local http server on an ephemeral port
@@ -68,6 +69,26 @@ describe('utils/http', () => {
       expect(headers['x-custom']).to.equal('yes')
       const body = await collect(stream)
       expect(body).to.equal('hello world')
+    })
+
+    it('decodes a gzip body and strips the stale content-encoding/length headers', async () => {
+      const payload = 'the quick brown fox '.repeat(50)
+      const gz = gzipSync(Buffer.from(payload))
+      server = await startServer((req, res) => {
+        res.writeHead(200, {
+          'content-type': 'text/plain',
+          'content-encoding': 'gzip',
+          'content-length': String(gz.length)
+        })
+        res.end(gz)
+      })
+      const { stream, headers } = await fetchStream(baseUrl(server))
+      // undici already decoded the body — the re-served headers must not still
+      // advertise gzip, or a downstream client double-decompresses and fails
+      expect(headers).to.not.have.property('content-encoding')
+      expect(headers).to.not.have.property('content-length')
+      const body = await collect(stream)
+      expect(body).to.equal(payload)
     })
 
     it('throws on a non-2xx status (axios throw-on-non-2xx contract)', async () => {

--- a/src/test/unit/http.test.ts
+++ b/src/test/unit/http.test.ts
@@ -1,0 +1,135 @@
+import { expect } from 'chai'
+import http, { Server } from 'http'
+import { AddressInfo } from 'net'
+import { Readable } from 'stream'
+import { fetchStream, fetchHeadersTimeout, headersToObject } from '../../utils/http.js'
+
+// spin up a throwaway local http server on an ephemeral port
+function startServer(handler: http.RequestListener): Promise<Server> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler)
+    server.listen(0, () => resolve(server))
+  })
+}
+
+function baseUrl(server: Server): string {
+  const { port } = server.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    // drop any hung/keep-alive sockets so close() actually resolves
+    server.closeAllConnections()
+    server.close(() => resolve())
+  })
+}
+
+async function collect(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+describe('utils/http', () => {
+  describe('headersToObject', () => {
+    it('produces a plain object with lowercase keys (Object.entries-friendly)', () => {
+      const headers = new Headers({
+        'X-Foo': 'bar',
+        'Content-Type': 'application/json'
+      })
+      const obj = headersToObject(headers)
+      expect(obj).to.deep.equal({
+        'x-foo': 'bar',
+        'content-type': 'application/json'
+      })
+      // consumers (downloadHandler) iterate with Object.entries — must work
+      expect(Object.entries(obj)).to.have.length(2)
+    })
+  })
+
+  describe('fetchStream', () => {
+    let server: Server
+    afterEach(async () => {
+      if (server) await stopServer(server)
+    })
+
+    it('returns a working Node Readable and a plain headers object on 2xx', async () => {
+      server = await startServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain', 'x-custom': 'yes' })
+        res.end('hello world')
+      })
+      const { httpStatus, stream, headers } = await fetchStream(baseUrl(server))
+      expect(httpStatus).to.equal(200)
+      expect(stream).to.be.instanceOf(Readable)
+      expect(headers['content-type']).to.equal('text/plain')
+      expect(headers['x-custom']).to.equal('yes')
+      const body = await collect(stream)
+      expect(body).to.equal('hello world')
+    })
+
+    it('throws on a non-2xx status (axios throw-on-non-2xx contract)', async () => {
+      server = await startServer((req, res) => {
+        res.writeHead(404, { 'content-type': 'text/plain' })
+        res.end('nope')
+      })
+      let threw = false
+      try {
+        await fetchStream(baseUrl(server))
+      } catch (err: any) {
+        threw = true
+        expect(err.message).to.contain('404')
+      }
+      expect(threw).to.equal(true)
+    })
+  })
+
+  describe('fetchHeadersTimeout', () => {
+    let server: Server
+    afterEach(async () => {
+      if (server) await stopServer(server)
+    })
+
+    it('aborts when headers never arrive within the timeout', async () => {
+      // handler intentionally never responds
+      server = await startServer(() => {})
+      let threw = false
+      try {
+        await fetchHeadersTimeout(baseUrl(server), { method: 'GET' }, 150)
+      } catch (err: any) {
+        threw = true
+        // undici surfaces the abort as an AbortError / "aborted"
+        expect(String(err.name + err.message).toLowerCase()).to.match(
+          /abort|headers timeout/
+        )
+      }
+      expect(threw).to.equal(true)
+    })
+
+    it('does NOT abort a slow body once headers have arrived', async () => {
+      // headers flush immediately, then the body drips out over ~250ms,
+      // which is well past the 100ms headers timeout — the full body must
+      // still arrive because the timer is cleared once headers resolve.
+      server = await startServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' })
+        res.flushHeaders()
+        let i = 0
+        const iv = setInterval(() => {
+          if (i >= 5) {
+            clearInterval(iv)
+            res.end()
+            return
+          }
+          res.write(`chunk${i}`)
+          i++
+        }, 50)
+      })
+      const response = await fetchHeadersTimeout(baseUrl(server), { method: 'GET' }, 100)
+      expect(response.status).to.equal(200)
+      const body = await collect(Readable.fromWeb(response.body as any))
+      expect(body).to.equal('chunk0chunk1chunk2chunk3chunk4')
+    })
+  })
+})

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -61,7 +61,9 @@ export async function fetchFileMetadata(
       30000
     )
     if (!response.ok) {
-      // axios threw on non-2xx before hashing — avoid checksumming an error page
+      // axios threw on non-2xx before hashing — avoid checksumming an error page.
+      // cancel the undrained body so undici releases the socket back to the pool.
+      await response.body?.cancel().catch(() => {})
       throw new Error(`Request failed with status code ${response.status} (${url})`)
     }
     contentType = response.headers.get('content-type') ?? ''

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { Service, DDOManager, DDO } from '@oceanprotocol/ddo-js'
 import { DDO_IDENTIFIER_PREFIX } from './constants.js'
 import { CORE_LOGGER } from './logging/common.js'
@@ -10,6 +9,7 @@ import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/interfac
 import ERC20Template4 from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20Template4.sol/ERC20Template4.json' with { type: 'json' }
 import { getContractAddress, getNFTFactory } from '../components/Indexer/utils.js'
 import { HeadersObject } from '../@types/fileObject.js'
+import { fetchHeadersTimeout } from './http.js'
 
 // Notes:
 // Asset as per asset.py on provider, is a class there, while on ocean.Js we only have a type
@@ -55,16 +55,20 @@ export async function fetchFileMetadata(
   const maxLength = isNaN(maxLengthInt) ? 10 * 1024 * 1024 : maxLengthInt
 
   try {
-    const response = await axios({
+    const response = await fetchHeadersTimeout(
       url,
-      method: method || 'get',
-      headers,
-      responseType: 'stream',
-      timeout: 30000
-    })
-    contentType = response.headers['content-type']
+      { method: method || 'GET', headers },
+      30000
+    )
+    if (!response.ok) {
+      // axios threw on non-2xx before hashing — avoid checksumming an error page
+      throw new Error(`Request failed with status code ${response.status} (${url})`)
+    }
+    contentType = response.headers.get('content-type') ?? ''
     let totalSize = 0
-    for await (const chunk of response.data) {
+    // web ReadableStream is async-iterable in Node 22; chunks are Uint8Array.
+    // break invokes the iterator's return() which cancels + releases the socket.
+    for await (const chunk of response.body ?? []) {
       totalSize += chunk.length
       contentChecksum.update(chunk)
       if (totalSize > maxLength && !forceChecksum) {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -60,11 +60,23 @@ export async function fetchStream(
   if (!response.body) {
     throw new Error(`Empty response body (${url})`)
   }
+  const headers = headersToObject(response.headers)
+  // undici transparently decodes gzip/deflate/br but leaves the original
+  // content-encoding + (now-wrong, compressed) content-length on the headers.
+  // The stream we return is already decoded, so strip those stale headers —
+  // otherwise a consumer re-serving them (e.g. downloadHandler) makes the client
+  // try to decompress plain bytes ("incorrect header check"). axios's stream
+  // adapter deleted these on decompress too.
+  const encoding = headers['content-encoding']
+  if (encoding && encoding.toLowerCase() !== 'identity') {
+    delete headers['content-encoding']
+    delete headers['content-length']
+  }
   return {
     httpStatus: response.status,
     // `response.body` is typed as the DOM ReadableStream; Node's fromWeb wants
     // the node:stream/web ReadableStream — structurally identical, cast locally.
     stream: Readable.fromWeb(response.body as any),
-    headers: headersToObject(response.headers)
+    headers
   }
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,69 @@
+import { Readable } from 'stream'
+
+/**
+ * Convert a fetch `Headers` instance into a plain object with lowercase keys,
+ * matching the shape axios used to expose on `response.headers`. Consumers that
+ * iterate with `Object.entries(...)` (e.g. downloadHandler) rely on a plain
+ * object here — `Object.entries(new Headers())` would yield `[]`.
+ */
+export function headersToObject(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers)
+}
+
+/**
+ * fetch with axios-like timeout semantics for streaming responses.
+ *
+ * The timer guards the connection + response-headers phase only. `fetch()`
+ * resolves as soon as the response headers arrive (the body may still be
+ * streaming), so clearing the timer in `finally` means long-running body
+ * streams (downloads, checksums) are never aborted mid-flight — the same
+ * behaviour axios had with `responseType: 'stream'` + `timeout`.
+ *
+ * Buffered callers that want the timeout to cover the full body should use
+ * plain `fetch(url, { signal: AbortSignal.timeout(ms) })` instead.
+ */
+export async function fetchHeadersTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(
+    () => controller.abort(new Error('Headers timeout')),
+    timeoutMs
+  )
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * GET/POST a URL and adapt the response to the `StorageReadable` contract:
+ * a Node `Readable` stream plus a plain lowercase-keyed headers object.
+ *
+ * Throws on non-2xx (axios threw on non-2xx by default; every storage caller
+ * relied on that) and on an empty response body.
+ */
+export async function fetchStream(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs = 30000
+): Promise<{ httpStatus: number; stream: Readable; headers: Record<string, string> }> {
+  const response = await fetchHeadersTimeout(url, init, timeoutMs)
+  if (!response.ok) {
+    // preserve axios's throw-on-non-2xx contract for all callers
+    throw new Error(`Request failed with status code ${response.status} (${url})`)
+  }
+  if (!response.body) {
+    throw new Error(`Empty response body (${url})`)
+  }
+  return {
+    httpStatus: response.status,
+    // `response.body` is typed as the DOM ReadableStream; Node's fromWeb wants
+    // the node:stream/web ReadableStream — structurally identical, cast locally.
+    stream: Readable.fromWeb(response.body as any),
+    headers: headersToObject(response.headers)
+  }
+}

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -54,6 +54,7 @@ export async function fetchStream(
   const response = await fetchHeadersTimeout(url, init, timeoutMs)
   if (!response.ok) {
     // preserve axios's throw-on-non-2xx contract for all callers
+    await response.body?.cancel().catch(() => {})
     throw new Error(`Request failed with status code ${response.status} (${url})`)
   }
   if (!response.body) {


### PR DESCRIPTION
Closes #1413 

# Migrate from `axios` to native Node.js `fetch`

### Summary

The codebase was running **two HTTP client stacks side by side**: native `fetch` (undici,
built into Node 22) is already the convention in newer code
(`policyServer/index.ts`, `c2d/compute_engine_docker.ts`, `utils/ip.ts`, `utils/database.ts`,
`P2P/*`), while older code still used `axios`. This PR removes the direct `axios`
dependency and converges every HTTP client call in our own code onto `fetch`.

Why:

- One HTTP stack instead of two — the one that ships with the platform.
- One fewer direct dependency to track for CVEs/upgrades (axios has a steady history of
  advisories: SSRF, ReDoS, `follow-redirects`).
- undici's pooled keep-alive agent is a good fit for the hot Typesense path.

**Honest caveat:** axios does **not** leave `node_modules`. It remains a _transitive_
dependency via `@ipshipyard/libp2p-auto-tls@2.0.1 → acme-client@5.4.0 → axios@1.15.0`
(`npm ls axios` confirms this is now the only path). The win is decoupling _our_ code and
converging on one stack — not disk space or lockfile removal. If acme-client ever drops
axios upstream, it disappears for free.

**Non-goals:** touching acme-client/auto-TLS; changing any public behavior, response
shapes, or the `StorageReadable` contract; adding a wrapper library (`node-fetch`/`ky`/`got`).

### What changed

- **New `src/utils/http.ts`** — a small (~70-line, zero-dependency) helper:
  - `headersToObject(headers)` — `Headers` → plain lowercase-keyed object (the shape axios
    exposed; consumers like `downloadHandler` iterate it with `Object.entries`, which
    yields `[]` on a raw `Headers` instance).
  - `fetchHeadersTimeout(url, init, ms)` — fetch with **axios-like streaming timeout
    semantics**: the timer guards the connect + response-headers phase only, then is
    cleared once `fetch()` resolves, so long-running body streams (downloads, checksums)
    are never aborted mid-flight. This is the one genuinely subtle part of the migration.
  - `fetchStream(url, init, ms)` — adapts a response to the `StorageReadable` contract
    (a Node `Readable` via `Readable.fromWeb`, plus a plain headers object) and **throws on
    non-2xx** to preserve axios's default throw-on-error behavior that every storage caller
    relied on.

- **`src/components/database/typesenseApi.ts`** (the careful one — every metadata op flows
  through `request<T>()`). The class shape, retry loop, node rotation, and `TypesenseError`
  are unchanged; only the transport inside `request()` was rewritten. It got **simpler**:
  axios's `validateStatus: (s) => s > 0` and the manual `transformResponse` were both
  re-implementing exactly what fetch does natively. Query params via `URLSearchParams`
  (scalars coerced to strings), JSON body via `JSON.stringify` + explicit content-type,
  JSON parsing gated on `content-type`. `customError()` signature changed from
  `(AxiosResponse)` to `(status, data)`. Retry-path debug log now reads
  `error.cause?.code ?? error.code` so `ECONNREFUSED`-style codes still appear (fetch wraps
  them in `TypeError: fetch failed` with the real error on `.cause`).

- **`src/components/storage/UrlStorage.ts`**
  - `getReadableStream()` → `fetchStream(input, { method: 'GET', headers }, 30000)`.
  - `upload()` (PUT with a Node `Readable` body) → `fetchHeadersTimeout` with
    `body: Readable.toWeb(stream)` + **`duplex: 'half'`** (mandatory in undici for streaming
    request bodies). Preserves axios's throw-on-non-2xx (the C2D results-upload caller
    relies on the throw to mark the job failed). Uploads stay chunked, same as before.

- **`src/components/storage/ArweaveStorage.ts` / `IpfsStorage.ts`** — `getReadableStream()`
  becomes a one-liner over `fetchStream`.

- **`src/utils/asset.ts`** — `fetchFileMetadata()` uses `fetchHeadersTimeout` and iterates
  the web `ReadableStream` directly (`for await`); chunks are `Uint8Array`, so `.length`
  and `hash.update()` work unchanged, and the early `break` at `MAX_CHECKSUM_LENGTH`
  cancels the stream / releases the socket (same cleanup axios gave). Adds an explicit
  non-2xx throw so error pages aren't checksummed.

- **`src/components/Indexer/purgatory.ts`** — two identical GET-JSON sites → `fetch` +
  `AbortSignal.timeout(2000)`.

- **`src/components/Indexer/processors/BaseProcessor.ts`** — **two** sites (see note below):
  the nonce `GET` and the decrypt `POST`.

- **Dependency + config**
  - `package.json` — `axios` removed from `dependencies` (`package-lock.json` drops the
    direct edge; the transitive edge via acme-client stays).
  - `.eslintrc` — added `RequestInit` to `globals` (see note below).

### Reviewer notes / behavior-preservation

1. **BaseProcessor had a second axios call.** Besides the nonce `GET`, `decryptDDO()` does a
   `POST /api/services/decrypt` wrapped in `withRetrial`, with a custom
   `validateStatus` (allow 2xx/400/403, throw otherwise). fetch never throws on status, so
   the migration relies on the **pre-existing manual status checks** (`400/403 → return`,
   `not 2xx → throw → retry`) to reproduce that contract exactly. The response is adapted to
   `{ status, statusText, data }` (data parsed by content-type, matching axios). The inner
   `ECONNREFUSED` retry check was extended to also inspect `err.cause?.code`.

2. **Dead branches become live (same outcome, better message).** Under axios, purgatory's
   non-2xx and BaseProcessor's nonce failures threw into the `catch`; the `status !== 200`
   branches were unreachable. With fetch they're now reached directly. The end result
   (empty purgatory list / `Date.now()` nonce fallback) is unchanged.

3. **Nonce fallback** now guards on `data?.nonce !== undefined` rather than the old truthy
   `data` check — a small hardening over a latent `String(NaN)` path when the endpoint
   returns a body without `nonce`. Normal responses behave identically.

4. **`.eslintrc` change.** `no-undef` doesn't understand the type-only `RequestInit`
   interface (the `browser` env only supplies runtime globals like `fetch`/`Response`,
   which is why inline-literal fetch callers never tripped it). Registered `RequestInit`
   as a global — one additive line.

5. **Pre-existing bug left untouched (flagging, not fixing):** typesenseApi's retry sleep is
   `await setTimeout(this.config.retryIntervalSeconds)`, which sleeps N **milliseconds**
   despite the "seconds" name. Preserved as-is; worth a separate commit with maintainer
   sign-off.

6. **Env knob for CI/Barge:** default `config.json` points Typesense at `http://localhost:8108`.
   undici's happy-eyeballs resolves `localhost` fine, but if integration ever shows
   `ECONNREFUSED ::1:8108`, switch the config to `127.0.0.1`.

### Files

| Change                      | Files                                                                                            |
| --------------------------- | ------------------------------------------------------------------------------------------------ |
| New helper + unit test      | `src/utils/http.ts`, `src/test/unit/http.test.ts`                                                |
| Buffered JSON swaps         | `Indexer/purgatory.ts`, `Indexer/processors/BaseProcessor.ts`                                    |
| Streaming swaps             | `storage/UrlStorage.ts`, `storage/ArweaveStorage.ts`, `storage/IpfsStorage.ts`, `utils/asset.ts` |
| Careful `request()` rewrite | `database/typesenseApi.ts`                                                                       |
| Dependency + lint config    | `package.json`, `package-lock.json`, `.eslintrc`                                                 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved network request reliability with clearer HTTP error handling and configurable timeouts.
  * Enhanced file downloads and uploads, including streaming support for URL, IPFS, and Arweave content.
  * Improved handling of compressed responses and response headers.
  * Added safeguards for unsuccessful or empty responses and better connection cleanup.

* **Bug Fixes**
  * Fixed metadata retrieval and service requests that could mishandle response formats or interrupted connections.

* **Tests**
  * Added coverage for streaming, timeouts, headers, compressed content, and HTTP error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->