### PR TITLE
fix extend service

### DIFF
--- a/src/components/core/service/extendService.ts
+++ b/src/components/core/service/extendService.ts
@@ -113,24 +113,38 @@ export class ServiceExtendHandler extends CommandHandler {
               buildInvalidRequestMessage('Service job not found: ' + task.serviceId)
             )
 
-          // State check — only Starting or Running can be extended
+          // Payment-phase check — Locking and Claiming are the start's own escrow phases:
+          // funds are locked but not yet settled. Charging a second, independent
+          // lock+claim for the same service while that is in flight risks tangling the two
+          // escrow flows (and the start may still cancel its lock and fail), so extension
+          // must wait until the start has settled into a stable state.
           if (
-            freshJob.status !== ServiceStatusNumber.Starting &&
-            freshJob.status !== ServiceStatusNumber.Running
+            freshJob.status === ServiceStatusNumber.Locking ||
+            freshJob.status === ServiceStatusNumber.Claiming
           )
             return buildInvalidParametersResponse(
               buildInvalidRequestMessage(
-                `Cannot extend a service in state "${freshJob.statusText}". Only Starting or Running services can be extended.`
+                `Cannot extend service ${task.serviceId} while its payment is in progress (state "${freshJob.statusText}") — retry once the service has started`
+              )
+            )
+
+          // Expiry check — every remaining state can be extended except an expired one:
+          // once the service's window is over there is nothing left to prolong (a new
+          // start is required). The others still have a live/pending job row whose
+          // expiresAt is meaningful. A passed expiresAt counts as expired even when the
+          // status still says otherwise: the expiry sweep runs on a cron, so there is
+          // always a window in which a de-facto expired job has not been relabelled yet.
+          const remainingSeconds = Math.floor((freshJob.expiresAt - Date.now()) / 1000)
+          if (freshJob.status === ServiceStatusNumber.Expired || remainingSeconds <= 0)
+            return buildInvalidParametersResponse(
+              buildInvalidRequestMessage(
+                `Cannot extend service ${task.serviceId}: it has expired (state "${freshJob.statusText}", expiresAt ${freshJob.expiresAt}). Expired services cannot be extended.`
               )
             )
 
           // Extension must not push total beyond maxDurationSeconds
           const sod = engine.getC2DConfig().connection?.serviceOnDemand
           const maxDuration = sod?.maxDurationSeconds ?? 86400
-          const remainingSeconds = Math.max(
-            0,
-            Math.floor((freshJob.expiresAt - Date.now()) / 1000)
-          )
           const newTotalDuration = remainingSeconds + task.additionalDuration
           if (newTotalDuration > maxDuration)
             return buildInvalidParametersResponse(

--- a/src/test/unit/service/serviceHandlers.test.ts
+++ b/src/test/unit/service/serviceHandlers.test.ts
@@ -453,12 +453,75 @@ describe('Service handlers', () => {
       expect(res.status.httpStatus).to.equal(401)
     })
 
-    it('400 when service is Stopped (bad state)', async () => {
-      const { node } = buildFakes({
-        serviceJobInDb: makeJob({ status: ServiceStatusNumber.Stopped })
+    it('400 while the start payment is in flight (Locking / Claiming)', async () => {
+      for (const [status, statusText] of [
+        [ServiceStatusNumber.Locking, 'Locking'],
+        [ServiceStatusNumber.Claiming, 'Claiming']
+      ] as const) {
+        const { node, escrow } = buildFakes({
+          serviceJobInDb: makeJob({ status, statusText })
+        })
+        const res = await new ServiceExtendHandler(node).handle({ ...baseTask } as any)
+        expect(res.status.httpStatus, statusText).to.equal(400)
+        expect(String(res.status.error)).to.contain('payment is in progress')
+        // no second escrow flow may be opened alongside the start's own
+        expect(escrow.createLock.called, statusText).to.equal(false)
+      }
+    })
+
+    it('400 when service is Expired', async () => {
+      const { node, escrow } = buildFakes({
+        serviceJobInDb: makeJob({
+          status: ServiceStatusNumber.Expired,
+          statusText: 'Expired'
+        })
       })
       const res = await new ServiceExtendHandler(node).handle({ ...baseTask } as any)
       expect(res.status.httpStatus).to.equal(400)
+      expect(String(res.status.error)).to.contain('expired')
+      // rejected before any escrow work
+      expect(escrow.createLock.called).to.equal(false)
+    })
+
+    it('400 when expiresAt has already passed, whatever the status says', async () => {
+      // the expiry sweep is a cron job, so a de-facto expired service can still carry a
+      // live status for a while — extend must reject it on expiresAt alone
+      for (const status of [ServiceStatusNumber.Running, ServiceStatusNumber.Stopped]) {
+        const { node, escrow } = buildFakes({
+          serviceJobInDb: makeJob({ status, expiresAt: Date.now() - 1000 })
+        })
+        const res = await new ServiceExtendHandler(node).handle({ ...baseTask } as any)
+        expect(res.status.httpStatus, `status=${status}`).to.equal(400)
+        expect(String(res.status.error)).to.contain('expired')
+        expect(escrow.createLock.called, `status=${status}`).to.equal(false)
+      }
+    })
+
+    it('200 for every other state', async () => {
+      for (const status of [
+        ServiceStatusNumber.Starting,
+        ServiceStatusNumber.PullImage,
+        ServiceStatusNumber.BuildImage,
+        ServiceStatusNumber.PullImageFailed,
+        ServiceStatusNumber.BuildImageFailed,
+        ServiceStatusNumber.VulnerableImage,
+        ServiceStatusNumber.Running,
+        ServiceStatusNumber.Restarting,
+        ServiceStatusNumber.Stopping,
+        ServiceStatusNumber.Stopped,
+        ServiceStatusNumber.Error
+      ]) {
+        const job = makeJob({ status })
+        const before = job.expiresAt
+        const { node } = buildFakes({ serviceJobInDb: job })
+        const res = await new ServiceExtendHandler(node).handle({ ...baseTask } as any)
+        expect(
+          res.status.httpStatus,
+          `status=${status}: ${res.status?.error ?? ''}`
+        ).to.equal(200)
+        const out = await body(res)
+        expect(out[0].expiresAt, `status=${status}`).to.equal(before + 3600 * 1000)
+      }
     })
 
     it('400 when extension exceeds maxDurationSeconds', async () => {


### PR DESCRIPTION
# Allow `SERVICE_EXTEND` on any service that has not expired or mid-payment

Replaces the `SERVICE_EXTEND` state gate. Previously only `Starting` and `Running` services
could be extended; now **every state is extendable except an expired one or one whose start
payment is still in flight** (`Locking`, `Claiming`). Expiry is judged by `expiresAt` rather
than by the status label alone. The duration cap (`maxDurationSeconds`) is unchanged and
remains the only other rejection.

## Motivation

The old gate rejected states that still represent a live, paid-for service. A consumer whose
service was mid-lifecycle — `PullImage`, `BuildImage`, `Restarting`, `Stopping` — or one
sitting in `Stopped`, `Error`, or an image-failure state could not buy more time for a job row
that still exists and still has a meaningful `expiresAt`.

Two categories genuinely must not be extended. `Expired` has nothing left to prolong: the
service is gone and a new start is required. `Locking` and `Claiming` are the **start's own
escrow phases** — funds are locked but not yet settled — and opening a second, independent
lock+claim for the same service alongside that risks tangling the two escrow flows, with the
start still free to cancel its lock and fail. Extension there must wait for the start to
settle.

The status label alone is not a sound expiry signal, because the expiry sweep runs on a cron.
There is always a window in which a service whose `expiresAt` has already passed still
carries a live status. Under a status-only gate, such a job would be extended, and because
the remaining-time calculation floored negatives at `0`, it would be granted the **full**
`maxDurationSeconds` window rather than being refused.

## What changed

**`src/components/core/service/extendService.ts`** — two gates, both evaluated inside the
per-service lifecycle lock on the freshly re-read job row.

Payment in flight:

```ts
if (
  freshJob.status === ServiceStatusNumber.Locking ||
  freshJob.status === ServiceStatusNumber.Claiming
)
  return buildInvalidParametersResponse(
    buildInvalidRequestMessage(
      `Cannot extend service ${task.serviceId} while its payment is in progress (state "${freshJob.statusText}") — retry once the service has started`
    )
  )
```

Expired:

```ts
const remainingSeconds = Math.floor((freshJob.expiresAt - Date.now()) / 1000)
if (freshJob.status === ServiceStatusNumber.Expired || remainingSeconds <= 0)
  return buildInvalidParametersResponse(
    buildInvalidRequestMessage(
      `Cannot extend service ${task.serviceId}: it has expired (state "${freshJob.statusText}", expiresAt ${freshJob.expiresAt}). Expired services cannot be extended.`
    )
  )
```

- `remainingSeconds` moved above the expiry gate and **dropped its `Math.max(0, …)` floor**.
  The floor existed only to keep a negative remainder out of the duration cap; negatives can
  no longer reach it, so the cap arithmetic (`remainingSeconds + additionalDuration >
  maxDuration`) is unchanged in behaviour for every input that now gets that far.
- Each rejection names the `serviceId` and the state; the expiry one names **both** signals —
  status and `expiresAt` — so an operator can distinguish a swept rejection from an unswept
  one.

Nothing else in the handler moved: ownership check, environment resolution, the access-list
re-check, the unresolved-intent recovery, and the escrow lock → claim → write sequence are
all untouched.

### Behavioural surface

| Job state | Before | After |
| --- | --- | --- |
| `Starting`, `Running` | extendable | extendable |
| `PullImage`, `BuildImage`, `Restarting`, `Stopping` | **rejected (400)** | extendable |
| `PullImageFailed`, `BuildImageFailed`, `VulnerableImage`, `Stopped`, `Error` | **rejected (400)** | extendable |
| `Locking`, `Claiming` | rejected (400) | rejected (400) — payment in flight |
| `Expired` | rejected (400) | rejected (400) |
| any other status, `expiresAt` already passed | **extendable, granted a full window** | **rejected (400)** |

Three consequences worth naming for reviewers:

- **Extending a `Stopped` or `Error` service charges escrow and pushes `expiresAt` forward,
  but nothing restarts the container.** The consumer pays for a window on a service that is
  not running. This follows directly from the "any state except expired / mid-payment" rule;
  if the intended flow is extend-then-restart that is fine, otherwise `Stopped`/`Error` may
  warrant their own rejection in a follow-up.
- **`Restarting` and `Stopping` are held by the same `runExclusive` lock** the handler takes,
  so extend cannot corrupt them — it will fail fast on the lock-busy path (400, nothing
  charged) rather than reaching the state gate. The explicit `Locking`/`Claiming` rejection is
  therefore about the *escrow* conflict, not the row-write race, and gives a clear message
  instead of a lock-busy one.
- **A service extended in the final second of its window can lose the race with the expiry
  sweep** and get a 400, since the gate reads `Date.now()` under the lock. That is the
  correct outcome — nothing is charged either way — but a client extending near expiry may
  need to start fresh rather than extend.

No other test needed changing. The integration case
`(j) SERVICE_EXTEND advances expiresAt and records an extendPayment` extends a `Running`
service; `(k)` relies on the DB owner filter, not on state; and the expiry-sweep race test in
`serviceRestartRace.test.ts` exercises the sweep's own snapshot check rather than the handler
gate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service extensions are now correctly blocked while payment processing is in progress.
  * Extensions are rejected for expired services, including services whose expiration time has passed.
  * Services in other valid states, including stopped services, can now be extended when they have not expired.
  * Extension duration and updated expiration details continue to be reflected in the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->