### PR TITLE
Bug/fix c2d unreachable db

### DIFF
--- a/src/components/database/index.ts
+++ b/src/components/database/index.ts
@@ -36,10 +36,33 @@ export class Database {
   sqliteConfig: SQLLiteConfigDatabase
   c2d: C2DDatabase
   authToken: AuthTokenDatabase
+  // true only when the metadata (Typesense/Elasticsearch) databases were all initialized.
+  // false in DEGRADED mode (metadata DB unreachable) and when no metadata DB is configured.
+  metadataInitialized: boolean = false
 
   constructor(private config: OceanNodeDBConfig) {}
 
-  static async init(config: OceanNodeDBConfig): Promise<Database | null> {
+  // When a metadata (Typesense/Elasticsearch) database fails to initialize we either give up
+  // (return null, so the caller keeps retrying while the DB comes up) or, when allowPartial is
+  // set, return the already-built SQLite core (nonce/config/c2d/authToken) so the node can run
+  // in DEGRADED mode with C2D / nonce / auth available but Indexer and DDO features disabled.
+  private static handleMetadataInitFailure(
+    db: Database,
+    allowPartial: boolean
+  ): Database | null {
+    if (allowPartial) {
+      DATABASE_LOGGER.warn(
+        'Metadata database unreachable — starting in DEGRADED mode: Indexer and DDO features are disabled, C2D / nonce / auth remain available'
+      )
+      return db
+    }
+    return null
+  }
+
+  static async init(
+    config: OceanNodeDBConfig,
+    allowPartial: boolean = false
+  ): Promise<Database | null> {
     const db = new Database(config)
     try {
       db.nonce = await DatabaseFactory.createNonceDatabase(config)
@@ -76,49 +99,51 @@ export class Database {
         db.ddo = await DatabaseFactory.createDdoDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`DDO database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
       try {
         db.indexer = await DatabaseFactory.createIndexerDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`Indexer database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
 
       try {
         db.logs = await DatabaseFactory.createLogDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`Logs database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
 
       try {
         db.order = await DatabaseFactory.createOrderDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`Order database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
 
       try {
         db.ddoState = await DatabaseFactory.createDdoStateDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`DDO State database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
 
       try {
         db.accessList = await DatabaseFactory.createAccessListDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`AccessList database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
 
       try {
         db.escrow = await DatabaseFactory.createEscrowDatabase(config)
       } catch (error) {
         DATABASE_LOGGER.error(`Escrow database initialization failed: ${error}`)
-        return null
+        return Database.handleMetadataInitFailure(db, allowPartial)
       }
+      // All metadata databases initialized successfully — this is a full (non-degraded) node.
+      db.metadataInitialized = true
     } else {
       DATABASE_LOGGER.info(
         'Invalid DB URL. Only Nonce, C2D, Auth Token and Config Databases are initialized.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,11 @@ async function initDatabaseWithRetry(
       !(await isReachableConnection(dbConfig.url))
 
     if (!notReachable) {
-      const database = await Database.init(dbConfig)
+      // On the final attempt allow a partial (DEGRADED) init: if the metadata DB is still
+      // unreachable we keep the working SQLite core (C2D / nonce / auth) instead of returning
+      // null. Earlier attempts keep returning null on metadata failure so we retry with backoff
+      // and give a slow-starting metadata DB time to come up (yielding a full node).
+      const database = await Database.init(dbConfig, isLastAttempt)
       if (database) {
         if (attempt > 1) {
           OCEAN_NODE_LOGGER.info(`Database initialized after ${attempt} attempts`)
@@ -164,6 +168,14 @@ const dbconn: Database | null = await initDatabaseWithRetry(
 )
 if (!dbconn) {
   OCEAN_NODE_LOGGER.error('Database failed to initialize')
+} else if (hasValidDBConfiguration(config.dbConfig) && !dbconn.metadataInitialized) {
+  // DEGRADED mode: SQLite core (C2D / nonce / auth) is up but the metadata DB (Typesense/
+  // Elasticsearch) is unreachable. The Indexer eagerly touches the metadata databases in its
+  // constructor, so it must not be started here.
+  config.hasIndexer = false
+  OCEAN_NODE_LOGGER.warn(
+    'Running in DEGRADED mode: metadata database is unavailable, Indexer is disabled. C2D / nonce / auth remain available.'
+  )
 }
 
 if (!hasValidDBConfiguration(config.dbConfig)) {


### PR DESCRIPTION
# Fix: keep C2D running when the metadata DB is unreachable (degraded mode)

**Problem.** When the metadata DB (Elasticsearch/Typesense) was unreachable at startup,
`Database.init()` returned `null` the moment any metadata sub-DB failed — discarding the whole
`Database`, including the already-built SQLite `c2d`/`nonce`/`auth`/`config` stores. The node then
logged the misleading `C2DDatabase is mandatory for compute engines!` and ran with no C2D, even
though the C2DDatabase is local SQLite and never needed the metadata DB.

**Fix.** `Database.init()` now returns the working SQLite core instead of nulling everything when
only the metadata layer fails, so the node boots in **degraded mode**: C2D / nonce / auth stay up,
Indexer and DDO features are disabled.

- `src/components/database/index.ts` — added `Database.init(config, allowPartial = false)` and a
  `metadataInitialized` flag. On a metadata sub-DB failure with `allowPartial`, it logs a clear
  DEGRADED-mode warning and returns the partial DB; otherwise it still returns `null` (unchanged).
  `metadataInitialized` is set `true` only when every metadata DB initializes.
- `src/index.ts` — `initDatabaseWithRetry` passes `allowPartial = isLastAttempt`, so retries still
  wait (with backoff) for a slow metadata DB and yield a full node; only the final attempt falls
  back to degraded. Startup now detects `!dbconn.metadataInitialized` and sets `config.hasIndexer =
  false` (the Indexer eagerly touches the metadata DBs in its constructor).

`addC2DEngines()` needs no change — with the partial DB, `db.c2d` is present and compute engines
start. Existing single-arg callers are unaffected (`allowPartial` defaults to `false`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a degraded startup mode that keeps core database functionality available when metadata services cannot initialize.
  * Final startup attempts can now provide access to C2D, nonce, and authentication features despite metadata service outages.

* **Bug Fixes**
  * Improved startup resilience by preventing complete application initialization failure when metadata databases are unavailable.
  * Automatically disables indexing when operating in degraded mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->