### PR TITLE
Fix: indexer silently skipping DDOs on transient provider errors

### DIFF
--- a/src/OceanNode.ts
+++ b/src/OceanNode.ts
@@ -114,16 +114,28 @@ export class OceanNode {
         if (!blockchainRegistry)
           blockchainRegistry = new BlockchainRegistry(keyManager, config)
       }
-      // teardown old instance if needed; retain the promise so a newly-created
-      // OceanIndexer can await it before crawling (see awaitPendingTeardown).
-      OceanNode.pendingTeardown =
-        this.instance?.tearDownAll().catch((err: unknown) => {
-          OCEAN_NODE_LOGGER.warn(
-            `Failed to tear down previous OceanNode instance: ${
-              err instanceof Error ? err.message : String(err)
-            }`
-          )
-        }) ?? null
+      // Teardown the old instance if needed, and retain the promise so a newly-created
+      // OceanIndexer can await it before crawling (see awaitPendingTeardown). Chain onto any
+      // still-pending teardown from an earlier replacement instead of overwriting it, so the
+      // barrier keeps covering every outstanding teardown, not just the most recent one.
+      const previousTeardown = OceanNode.pendingTeardown
+      const instanceToTearDown = this.instance
+      OceanNode.pendingTeardown = (async () => {
+        if (previousTeardown) {
+          await previousTeardown
+        }
+        if (instanceToTearDown) {
+          try {
+            await instanceToTearDown.tearDownAll()
+          } catch (err: unknown) {
+            OCEAN_NODE_LOGGER.warn(
+              `Failed to tear down previous OceanNode instance: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            )
+          }
+        }
+      })()
       OCEAN_NODE_LOGGER.debug('Creating new OceanNode instance')
       this.instance = new OceanNode(
         config,

--- a/src/OceanNode.ts
+++ b/src/OceanNode.ts
@@ -36,6 +36,10 @@ export interface RequestDataCheck {
 }
 export class OceanNode {
   private static instance: OceanNode
+  // In-flight teardown of the previous instance (set by getInstance). A newly-created
+  // OceanIndexer awaits this before crawling, so it never overlaps a dying indexer on
+  // the same DB/chain while that instance's provider is being destroyed.
+  private static pendingTeardown: Promise<void> | null = null
   // handlers
   private coreHandlers: CoreHandlersRegistry
   // compute engines
@@ -110,14 +114,16 @@ export class OceanNode {
         if (!blockchainRegistry)
           blockchainRegistry = new BlockchainRegistry(keyManager, config)
       }
-      // teardown old instance if needed
-      this.instance?.tearDownAll().catch((err: unknown) => {
-        OCEAN_NODE_LOGGER.warn(
-          `Failed to tear down previous OceanNode instance: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        )
-      })
+      // teardown old instance if needed; retain the promise so a newly-created
+      // OceanIndexer can await it before crawling (see awaitPendingTeardown).
+      OceanNode.pendingTeardown =
+        this.instance?.tearDownAll().catch((err: unknown) => {
+          OCEAN_NODE_LOGGER.warn(
+            `Failed to tear down previous OceanNode instance: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          )
+        }) ?? null
       OCEAN_NODE_LOGGER.debug('Creating new OceanNode instance')
       this.instance = new OceanNode(
         config,
@@ -132,6 +138,22 @@ export class OceanNode {
       OCEAN_NODE_LOGGER.debug('Return cached OceanNode instance')
     }
     return this.instance
+  }
+
+  /**
+   * Await a previous instance's in-flight teardown (set by getInstance) so callers such as a
+   * freshly-constructed OceanIndexer don't start crawling while the old instance is still
+   * shutting down its indexer and destroying its provider. No-op when nothing is pending.
+   */
+  public static async awaitPendingTeardown(): Promise<void> {
+    const pending = OceanNode.pendingTeardown
+    if (pending) {
+      await pending
+      // Only clear if a newer teardown didn't replace it while we were awaiting.
+      if (OceanNode.pendingTeardown === pending) {
+        OceanNode.pendingTeardown = null
+      }
+    }
   }
 
   // in the future we should remove these 'add' methods as well

--- a/src/components/Indexer/ChainIndexer.ts
+++ b/src/components/Indexer/ChainIndexer.ts
@@ -475,6 +475,13 @@ export class ChainIndexer {
           })
         }
       } catch (error) {
+        if (isProviderError(error)) {
+          // Transient provider failure: preserve the task for a later retry (do not emit
+          // REINDEX_QUEUE_POP) and rethrow so the loop's outer catch holds the cursor,
+          // sleeps, and re-acquires a healthy provider before retrying.
+          this.reindexQueue.unshift(reindexTask)
+          throw error
+        }
         INDEXER_LOGGER.log(
           LOG_LEVELS_STR.LEVEL_ERROR,
           `REINDEX Error for tx ${reindexTask.txId}: ${error.message}`,

--- a/src/components/Indexer/ChainIndexer.ts
+++ b/src/components/Indexer/ChainIndexer.ts
@@ -12,6 +12,7 @@ import {
   getCrawlingInterval,
   getDeployedContractBlock,
   getNetworkHeight,
+  isProviderError,
   retrieveChunkEvents
 } from './utils.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
@@ -168,8 +169,8 @@ export class ChainIndexer {
       `Initial details for chain ${this.blockchain.getSupportedChain()}: RPCS start block: ${this.rpcDetails.startBlock}, Contract deployment block: ${contractDeploymentBlock}, Crawling start block: ${crawlingStartBlock}`
     )
 
-    const provider = await this.blockchain.getProvider()
-    const signer = await this.blockchain.getSigner()
+    let provider = await this.blockchain.getProvider()
+    let signer = await this.blockchain.getSigner()
     const interval = getCrawlingInterval()
     let chunkSize = this.rpcDetails.chunkSize || 1
     let successfulRetrievalCount = 0
@@ -182,6 +183,12 @@ export class ChainIndexer {
         lockProcessing = true
 
         try {
+          // Self-heal: if the provider was destroyed (overlapping teardown), getProvider()
+          // recreates it and getSigner() rebuilds against it. When healthy, both return the
+          // cached instances at negligible cost.
+          provider = await this.blockchain.getProvider()
+          signer = await this.blockchain.getSigner()
+
           const lastIndexedBlock = await this.getLastIndexedBlock()
           const networkHeight = await getNetworkHeight(provider)
           const startBlock =
@@ -222,6 +229,8 @@ export class ChainIndexer {
               )
               successfulRetrievalCount++
             } catch (error) {
+              // Rethrow so the outer catch retries this range instead of advancing past it.
+              if (isProviderError(error)) throw error
               INDEXER_LOGGER.log(
                 LOG_LEVELS_STR.LEVEL_WARN,
                 `Get events for network: ${this.rpcDetails.network} failure: ${error.message} \n\nConsider that there may be an issue with your RPC provider. We recommend using private RPCs from reliable providers such as Infura or Alchemy.`,

--- a/src/components/Indexer/index.ts
+++ b/src/components/Indexer/index.ts
@@ -42,6 +42,7 @@ import { getPackageVersion } from '../../utils/version.js'
 import { DB_EVENTS, ES_CONNECTION_EVENTS } from '../database/ElasticsearchConfigHelper.js'
 import { OceanNodeConfig } from '../../@types/OceanNode.js'
 import { clearEventProcessorCache } from './processor.js'
+import { OceanNode } from '../../OceanNode.js'
 
 /**
  * Event emitter for DDO (Data Descriptor Object) events
@@ -313,6 +314,11 @@ export class OceanIndexer {
 
   // Start all chain indexers
   public async startAllChainIndexers(): Promise<boolean> {
+    // Close the overlap at its source: wait for a previous OceanNode instance's teardown
+    // (its indexer stop + provider destroy) to finish before this indexer starts crawling,
+    // so two indexers never run concurrently against the same DB/chain.
+    await OceanNode.awaitPendingTeardown()
+
     await this.checkAndTriggerReindexing()
 
     // Setup event listeners for all chains (they all use the same event emitter)

--- a/src/components/Indexer/processors/AddressAddedEventProcessor.ts
+++ b/src/components/Indexer/processors/AddressAddedEventProcessor.ts
@@ -37,6 +37,7 @@ export class AddressAddedEventProcessor extends BaseEventProcessor {
       )
       return result
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(
         LOG_LEVELS_STR.LEVEL_ERROR,
         `Error processing AddressAdded event: ${err.message}`,

--- a/src/components/Indexer/processors/AddressRemovedEventProcessor.ts
+++ b/src/components/Indexer/processors/AddressRemovedEventProcessor.ts
@@ -35,6 +35,7 @@ export class AddressRemovedEventProcessor extends BaseEventProcessor {
       )
       return result
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(
         LOG_LEVELS_STR.LEVEL_ERROR,
         `Error processing AddressRemoved event: ${err.message}`,

--- a/src/components/Indexer/processors/BaseProcessor.ts
+++ b/src/components/Indexer/processors/BaseProcessor.ts
@@ -24,7 +24,7 @@ import ERC721Template from '@oceanprotocol/contracts/artifacts/contracts/templat
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import ERC20Template from '@oceanprotocol/contracts/artifacts/contracts/templates/ERC20TemplateEnterprise.sol/ERC20TemplateEnterprise.json' with { type: 'json' }
 import { fetchTransactionReceipt } from '../../core/utils/validateOrders.js'
-import { withRetrial } from '../utils.js'
+import { withRetrial, isProviderError } from '../utils.js'
 import { OceanNodeConfig } from '../../../@types/OceanNode.js'
 import { Database } from '../../../components/database/index.js'
 
@@ -39,6 +39,14 @@ export abstract class BaseEventProcessor {
 
   getConfig(): OceanNodeConfig {
     return this.config
+  }
+
+  /**
+   * Rethrow transient provider/RPC failures so the crawl loop can retry the chunk instead of the
+   * event processor swallowing them and letting the cursor advance past an un-stored asset.
+   */
+  protected rethrowIfProviderError(err: any): void {
+    if (isProviderError(err)) throw err
   }
 
   async getDatabase(): Promise<Database> {

--- a/src/components/Indexer/processors/DispenserActivatedEventProcessor.ts
+++ b/src/components/Indexer/processors/DispenserActivatedEventProcessor.ts
@@ -112,6 +112,7 @@ export class DispenserActivatedEventProcessor extends BaseEventProcessor {
       )
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/DispenserCreatedEventProcessor.ts
+++ b/src/components/Indexer/processors/DispenserCreatedEventProcessor.ts
@@ -115,6 +115,7 @@ export class DispenserCreatedEventProcessor extends BaseEventProcessor {
       const savedDDO = await this.createOrUpdateDDO(ddoInstance, EVENTS.DISPENSER_CREATED)
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/DispenserDeactivatedEventProcessor.ts
+++ b/src/components/Indexer/processors/DispenserDeactivatedEventProcessor.ts
@@ -121,6 +121,7 @@ export class DispenserDeactivatedEventProcessor extends BaseEventProcessor {
       )
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/EscrowEventProcessor.ts
+++ b/src/components/Indexer/processors/EscrowEventProcessor.ts
@@ -112,6 +112,7 @@ export class EscrowEventProcessor extends BaseEventProcessor {
       )
       return result
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(
         LOG_LEVELS_STR.LEVEL_ERROR,
         `Error processing Escrow ${eventName} event: ${err.message}`,

--- a/src/components/Indexer/processors/ExchangeActivatedEventProcessor.ts
+++ b/src/components/Indexer/processors/ExchangeActivatedEventProcessor.ts
@@ -120,6 +120,7 @@ export class ExchangeActivatedEventProcessor extends BaseEventProcessor {
       )
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/ExchangeCreatedEventProcessor.ts
+++ b/src/components/Indexer/processors/ExchangeCreatedEventProcessor.ts
@@ -115,6 +115,7 @@ export class ExchangeCreatedEventProcessor extends BaseEventProcessor {
       const savedDDO = await this.createOrUpdateDDO(ddoInstance, EVENTS.EXCHANGE_CREATED)
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/ExchangeDeactivatedEventProcessor.ts
+++ b/src/components/Indexer/processors/ExchangeDeactivatedEventProcessor.ts
@@ -39,6 +39,7 @@ export class ExchangeDeactivatedEventProcessor extends BaseEventProcessor {
     try {
       exchange = await freContract.getExchange(exchangeId)
     } catch (e) {
+      this.rethrowIfProviderError(e)
       INDEXER_LOGGER.error(`Could not fetch exchange details: ${e.message}`)
     }
     if (!exchange) {

--- a/src/components/Indexer/processors/ExchangeDeactivatedEventProcessor.ts
+++ b/src/components/Indexer/processors/ExchangeDeactivatedEventProcessor.ts
@@ -125,6 +125,7 @@ export class ExchangeDeactivatedEventProcessor extends BaseEventProcessor {
       )
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/ExchangeRateChangedEventProcessor.ts
+++ b/src/components/Indexer/processors/ExchangeRateChangedEventProcessor.ts
@@ -120,6 +120,7 @@ export class ExchangeRateChangedEventProcessor extends BaseEventProcessor {
       )
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(
         LOG_LEVELS_STR.LEVEL_ERROR,
         `Error processing ExchangeRateChangedEvent: ${err}`,

--- a/src/components/Indexer/processors/MetadataEventProcessor.ts
+++ b/src/components/Indexer/processors/MetadataEventProcessor.ts
@@ -374,6 +374,7 @@ export class MetadataEventProcessor extends BaseEventProcessor {
         return saveDDO
       }
     } catch (error) {
+      this.rethrowIfProviderError(error)
       const { ddoState } = await this.getDatabase()
       await ddoState.update(
         this.networkId,

--- a/src/components/Indexer/processors/MetadataStateEventProcessor.ts
+++ b/src/components/Indexer/processors/MetadataStateEventProcessor.ts
@@ -92,6 +92,7 @@ export class MetadataStateEventProcessor extends BaseEventProcessor {
       const savedDDO = await this.createOrUpdateDDO(ddoInstance, EVENTS.METADATA_STATE)
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/NewAccessListEventProcessor.ts
+++ b/src/components/Indexer/processors/NewAccessListEventProcessor.ts
@@ -63,6 +63,7 @@ export class NewAccessListEventProcessor extends BaseEventProcessor {
       )
       return result
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(
         LOG_LEVELS_STR.LEVEL_ERROR,
         `Error processing NewAccessList event: ${err.message}`,

--- a/src/components/Indexer/processors/NewAccessListEventProcessor.ts
+++ b/src/components/Indexer/processors/NewAccessListEventProcessor.ts
@@ -41,6 +41,7 @@ export class NewAccessListEventProcessor extends BaseEventProcessor {
         name = nameRaw
         symbol = symbolRaw
       } catch (err) {
+        this.rethrowIfProviderError(err)
         INDEXER_LOGGER.log(
           LOG_LEVELS_STR.LEVEL_WARN,
           `Failed to read on-chain metadata for ${contractAddress}: ${err.message}`

--- a/src/components/Indexer/processors/OrderReusedEventProcessor.ts
+++ b/src/components/Indexer/processors/OrderReusedEventProcessor.ts
@@ -122,6 +122,7 @@ export class OrderReusedEventProcessor extends BaseEventProcessor {
       const savedDDO = await this.createOrUpdateDDO(ddoInstance, EVENTS.ORDER_REUSED)
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/processors/OrderStartedEventProcessor.ts
+++ b/src/components/Indexer/processors/OrderStartedEventProcessor.ts
@@ -99,6 +99,7 @@ export class OrderStartedEventProcessor extends BaseEventProcessor {
       const savedDDO = await this.createOrUpdateDDO(ddoInstance, EVENTS.ORDER_STARTED)
       return savedDDO
     } catch (err) {
+      this.rethrowIfProviderError(err)
       INDEXER_LOGGER.log(LOG_LEVELS_STR.LEVEL_ERROR, `Error retrieving DDO: ${err}`, true)
     }
   }

--- a/src/components/Indexer/utils.ts
+++ b/src/components/Indexer/utils.ts
@@ -15,6 +15,25 @@ import { ServicePrice } from '../../@types/IndexedMetadata.js'
 import { VersionedDDO } from '@oceanprotocol/ddo-js'
 import FactoryRouter from '@oceanprotocol/contracts/artifacts/contracts/pools/FactoryRouter.sol/FactoryRouter.json' with { type: 'json' }
 
+/**
+ * Distinguishes a transient provider/RPC failure (destroyed provider, network error, timeout,
+ * cancelled in-flight request) from a legitimate business outcome, so contract-call catches can
+ * rethrow provider errors instead of swallowing them and letting the crawl loop advance the
+ * cursor past an asset it never stored.
+ */
+export function isProviderError(err: any): boolean {
+  const code = err?.code
+  const msg = String(err?.message ?? err ?? '')
+  return (
+    code === 'NETWORK_ERROR' ||
+    code === 'SERVER_ERROR' ||
+    code === 'TIMEOUT' ||
+    (code === 'UNSUPPORTED_OPERATION' && /provider destroyed/i.test(msg)) ||
+    /provider destroyed/i.test(msg) ||
+    /cancelled request/i.test(msg)
+  )
+}
+
 export const getContractAddress = (chainId: number, contractName: string): string => {
   const addressFile = getOceanArtifactsAdressesByChainId(chainId)
   if (addressFile && contractName in addressFile) {
@@ -33,6 +52,7 @@ export const isValidFreContract = async (
   try {
     return await routerContract.isFixedRateContract(address)
   } catch (e) {
+    if (isProviderError(e)) throw e
     INDEXER_LOGGER.error(`Could not fetch FRE contract status: ${e.message}`)
   }
 }
@@ -47,6 +67,7 @@ export const isValidDispenserContract = async (
   try {
     return await routerContract.isDispenserContract(address)
   } catch (e) {
+    if (isProviderError(e)) throw e
     INDEXER_LOGGER.error(`Could not fetch dispenser contract status: ${e.message}`)
   }
 }
@@ -237,11 +258,13 @@ export async function getPricesByDt(
   try {
     dispensers = await datatoken.getDispensers()
   } catch (e) {
+    if (isProviderError(e)) throw e
     INDEXER_LOGGER.error(`[GET PRICES] failure when retrieving dispensers: ${e}`)
   }
   try {
     fixedRates = await datatoken.getFixedRates()
   } catch (e) {
+    if (isProviderError(e)) throw e
     INDEXER_LOGGER.error(
       `[GET PRICES] failure when retrieving fixed rate exchanges: ${e}`
     )
@@ -328,11 +351,13 @@ export async function getPricingStatsForDddo(
     try {
       dispensers = await datatoken.getDispensers()
     } catch (e) {
+      if (isProviderError(e)) throw e
       INDEXER_LOGGER.error(`Contract call fails when retrieving dispensers: ${e}`)
     }
     try {
       fixedRates = await datatoken.getFixedRates()
     } catch (e) {
+      if (isProviderError(e)) throw e
       INDEXER_LOGGER.error(
         `Contract call fails when retrieving fixed rate exchanges: ${e}`
       )
@@ -371,6 +396,7 @@ export async function getPricingStatsForDddo(
               })
             }
           } catch (e) {
+            if (isProviderError(e)) throw e
             INDEXER_LOGGER.error(
               `[GET PRICES] failure when retrieving dispenser status from contracts: ${e}`
             )
@@ -407,6 +433,7 @@ export async function getPricingStatsForDddo(
             })
           }
         } catch (e) {
+          if (isProviderError(e)) throw e
           INDEXER_LOGGER.error(
             `[GET PRICES] failure when retrieving exchange status from contracts: ${e}`
           )

--- a/src/components/Indexer/utils.ts
+++ b/src/components/Indexer/utils.ts
@@ -288,6 +288,7 @@ export async function getPricesByDt(
             })
           }
         } catch (e) {
+          if (isProviderError(e)) throw e
           INDEXER_LOGGER.error(
             `[GET PRICES] failure when retrieving dispenser status from contracts: ${e}`
           )
@@ -315,6 +316,7 @@ export async function getPricesByDt(
             })
           }
         } catch (e) {
+          if (isProviderError(e)) throw e
           INDEXER_LOGGER.error(
             `[GET PRICES] failure when retrieving exchange status from contracts: ${e}`
           )

--- a/src/components/c2d/compute_engine_base.ts
+++ b/src/components/c2d/compute_engine_base.ts
@@ -904,8 +904,9 @@ export abstract class C2DEngine {
 
     for (const resource of activeResources) {
       const res = this.getResource(resources, resource.id)
-      if (res.init && res.init.advanced) {
-        for (const [key, value] of Object.entries(res.init.advanced)) {
+      const advanced = res?.init?.advanced
+      if (advanced) {
+        for (const [key, value] of Object.entries(advanced)) {
           switch (key) {
             case 'IpcMode':
               ret.IpcMode = value as string

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -61,6 +61,8 @@ export class Blockchain {
       // 2. Destroy the FallbackProvider itself
       this.provider.destroy()
       this.provider = null
+      // Cached signer is bound to the destroyed provider; getSigner() only rebuilds when falsy.
+      this.signer = undefined as unknown as Signer
     }
   }
 


### PR DESCRIPTION
# Fix: indexer silently skipping DDOs on transient provider errors

## Problem

Under transient RPC conditions (provider failover, node restart, socket timeout, or an
overlapping indexer teardown destroying a provider mid-crawl), the indexer could **silently drop
an asset and advance its cursor past it** — the DDO would never be indexed and would only reappear
after a manual chain reindex.

The mechanism:

1. Every event processor wraps its work in a `try/catch` that logs and returns `null`/`undefined`.
   A `provider destroyed` / network error inside `processEvent` was therefore indistinguishable, to
   the caller, from a legitimate "nothing to do".
2. `processChunkLogs` / `processBlocks` never threw, `processBlocks` returned
   `lastBlock = lastIndexedBlock + count`, and `updateLastIndexedBlockNumber` **advanced the cursor**
   past the un-stored asset.
3. The crawl loop's existing `catch` (which correctly holds the cursor, sleeps, and retries) was
   never reached, because the error was swallowed one level deeper.

This surfaced as an intermittent integration-test failure (`should get stats for fre` in
`pricing.test.ts`) on the Node 24 / ethers 6.17 timing change, where a `provider destroyed;
cancelled request` during a crawl caused the DDO to be lost — but it is a genuine production
robustness bug independent of the tests.

## Approach

Two complementary fixes:

1. **Make the indexer self-healing** so it is correct under _any_ transient provider/RPC error,
   from whatever source. The guiding rule: **a transient provider/RPC error must fail the chunk
   (retry, cursor held); a legitimate business result — including a genuine `null` — must be left
   exactly as before.** A provider error is now *distinguished* from a business skip and rethrown so
   it lands in the crawl loop's existing retry path, instead of being swallowed.
2. **Close the overlap at its source** so the specific race that exposed the bug — a dying
   indexer's provider being destroyed while a crawl is still using it — can no longer happen: a
   newly-created indexer waits for the previous `OceanNode` instance's teardown to finish before it
   starts crawling.

The self-healing layer (1) keeps `OceanNode.getInstance`'s synchronous signature untouched and
makes overlap _safe_; the teardown-await (2) makes overlap _not happen_. Together they are
defence-in-depth.

## Changes (21 files, +100/-11)

### 1. Error classifier — `src/components/Indexer/utils.ts`

- New `isProviderError(err)` — narrowly matches transient ethers failures only: codes
  `NETWORK_ERROR`, `SERVER_ERROR`, `TIMEOUT`, `UNSUPPORTED_OPERATION` with a `provider destroyed`
  message, plus the `provider destroyed` / `cancelled request` message fragments.
- Guards the **8 contract-call catches** in this file (`isValidFreContract`,
  `isValidDispenserContract`, `getPricesByDt` ×2, `getPricingStatsForDddo` ×4) with
  `if (isProviderError(e)) throw e` as the first statement — otherwise a provider death mid-pricing
  would save a DDO with silently-empty `stats` and still advance the cursor.

### 2. Shared guard — `src/components/Indexer/processors/BaseProcessor.ts`

- New `protected rethrowIfProviderError(err)` helper (imports `isProviderError`).
- Called as the first statement of the top-level `catch` in **all 15 event processors**
  (`MetadataEventProcessor`, the four `Exchange*`, three `Dispenser*`, `Order{Started,Reused}`,
  `MetadataState`, `Address{Added,Removed}`, `NewAccessList`, `Escrow`). In
  `MetadataEventProcessor` the guard is placed **before** the `ddoState.update(..., false, ...)`
  call, so a transient blip is not persisted as a permanent DDO failure.

### 3. Self-healing crawl loop — `src/components/Indexer/ChainIndexer.ts`

- `provider` / `signer` changed from `const` to `let` and **re-acquired at the top of each loop
  iteration**. If the provider was destroyed by an overlapping teardown, `getProvider()` recreates
  it and `getSigner()` rebuilds against it; when healthy, both return the cached instances at
  negligible cost.
- Rethrows provider errors from the `retrieveChunkEvents` catch, so a failed `eth_getLogs` doesn't
  fall through to `processBlocks([])` and advance the cursor over an empty result. Propagated errors
  land in the loop's outer `catch`, which sleeps `interval` and retries the same range.

### 4. Reset cached signer on stop — `src/utils/blockchain.ts`

- `Blockchain.stop()` now clears the cached `signer` after destroying the provider. The signer is
  bound to the destroyed provider and `getSigner()` only rebuilds when it is falsy.

### 5. Close the overlap window — `src/OceanNode.ts` + `src/components/Indexer/index.ts`

The root cause of the exposing race: `getInstance(..., newInstance=true)` fired the previous
instance's `tearDownAll()` **without awaiting it**, while a freshly-constructed `OceanIndexer`
auto-starts crawling from its constructor — so a dying indexer briefly ran alongside the new one on
the same DB/chain, and the teardown's `provider.destroy()` could land mid-crawl.

- `OceanNode` now **retains the teardown promise** in a private static `pendingTeardown` (set in
  `getInstance` where the old instance is torn down) and exposes
  `static async awaitPendingTeardown()`, which awaits it once and clears it (guarding against a
  newer teardown replacing it while awaiting). The `getInstance` signature is unchanged — it still
  returns synchronously and does not await.
- `OceanIndexer.startAllChainIndexers()` **awaits `OceanNode.awaitPendingTeardown()`** as its first
  step, before `checkAndTriggerReindexing()` and before starting any `ChainIndexer`. Since
  `getInstance` (which sets the promise) always runs before the new `OceanIndexer` is constructed,
  the new indexer cannot begin crawling until the previous instance's indexer has stopped and its
  provider has been destroyed.

This introduces an import edge `Indexer/index.ts → OceanNode.ts` (on top of the existing
`OceanNode.ts → Indexer/index.ts`). The cycle is safe: `OceanNode` is referenced only inside a
method body at runtime, never at module-evaluation time — verified by loading the built module
graph in both import orders.

## Why it's safe

- **Idempotent reprocessing.** `createOrUpdateDDO` upserts via `ddoDatabase.update`, and
  `MetadataEventProcessor` short-circuits same-txid reprocessing — no duplication/corruption on retry.
- **No new unbounded loop.** Recovery replaces a dead provider on the next iteration; a genuinely
  down RPC now stalls that chain (retry every `interval`) instead of dropping assets, bounded by the
  existing `catch → sleep(interval)`.
- **Narrow classifier.** Only the listed ethers codes / message fragments count; every other path
  keeps its previous log-and-continue behaviour, so no legitimate business outcome (including a
  genuine `null`, e.g. an exchange not approved by the Router) changes.
- **No deadlock from the teardown-await.** `awaitPendingTeardown()` waits on the _old_ instance's
  teardown (stops the _old_ indexer, destroys the _old_ provider); it never depends on the new
  indexer, and an already-resolved promise is awaited instantly. On the DB-reconnect path there is
  no pending teardown, so it is a no-op.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing reliability during temporary blockchain provider or network failures.
  * Indexing now retries affected block ranges instead of skipping data when provider errors occur.
  * Prevented stale blockchain connections from being reused after shutdown.
  * Ensured previous indexing activity fully stops before a new indexing run begins.
* **Reliability**
  * Improved recovery from timeouts, cancelled requests, unavailable providers, and other transient connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->